### PR TITLE
♻️ refactor: 예외 처리 구조 개선 

### DIFF
--- a/src/main/java/com/sw8080/lookeng/DuplicateEmailException.java
+++ b/src/main/java/com/sw8080/lookeng/DuplicateEmailException.java
@@ -1,7 +1,0 @@
-package com.sw8080.lookeng;
-
-public class DuplicateEmailException extends RuntimeException {
-    public DuplicateEmailException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/sw8080/lookeng/GlobalExceptionHandler.java
+++ b/src/main/java/com/sw8080/lookeng/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.sw8080.lookeng;
 
 import com.sw8080.lookeng.dto.response.CommonResponse;
+import com.sw8080.lookeng.exception.BusinessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -10,7 +11,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // [400 Bad Request] 이메일 형식 오류 / 비밀번호 공백 (@Valid 에러 가로채기)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CommonResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
         String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
@@ -18,10 +18,9 @@ public class GlobalExceptionHandler {
                 .body(new CommonResponse<>(false, errorMessage, null));
     }
 
-    // [401 Unauthorized] 이메일·비밀번호 불일치 또는 탈퇴 계정
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<CommonResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<CommonResponse<Void>> handleBusinessException(BusinessException e) {
+        return ResponseEntity.status(e.getStatus())
                 .body(new CommonResponse<>(false, e.getMessage(), null));
     }
 }

--- a/src/main/java/com/sw8080/lookeng/controller/AuthController.java
+++ b/src/main/java/com/sw8080/lookeng/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.sw8080.lookeng.controller;
 
 import com.sw8080.lookeng.ApiResponse;
+import com.sw8080.lookeng.exception.UnauthorizedException;
 import com.sw8080.lookeng.dto.request.LoginRequestDto;
 import com.sw8080.lookeng.dto.request.SignupRequestDto;
 import com.sw8080.lookeng.dto.response.CommonResponse;
@@ -70,7 +71,7 @@ public class AuthController {
         // 2. 명세서 에러 응답(401): 세션이 없거나 이미 로그아웃된 상태라면 에러 발생
         if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
             // 우리가 GlobalExceptionHandler에 설정해둔 401 에러를 발생시킵니다.
-            throw new IllegalArgumentException("세션이 없습니다. (미로그인 상태)");
+            throw new UnauthorizedException("세션이 없습니다. (미로그인 상태)");
         }
 
         // 3. 세션 무효화 (출입증 폐기)

--- a/src/main/java/com/sw8080/lookeng/controller/TestSessionController.java
+++ b/src/main/java/com/sw8080/lookeng/controller/TestSessionController.java
@@ -54,22 +54,8 @@ public class TestSessionController {
         }
 
         Long userId = (Long) session.getAttribute("LOGIN_USER_ID");
-
-        try {
-            // 2. 비즈니스 로직 실행
-            TestAnswerResponseDto data = testSessionService.submitAnswer(userId, sessionId, request);
-            return ResponseEntity.ok(new ApiResponse<>(true, "답안이 제출되었습니다.", data));
-
-        } catch (IllegalArgumentException e) {
-            // 3. 권한(403) 또는 데이터 없음(404) 에러를 간편하게 400으로 통일하여 처리
-            // (실무에서는 GlobalExceptionHandler를 통해 세밀하게 나눕니다)
-            if (e.getMessage().contains("본인의 테스트 세션")) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                        .body(new ApiResponse<>(false, e.getMessage(), null));
-            }
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new ApiResponse<>(false, e.getMessage(), null));
-        }
+        TestAnswerResponseDto data = testSessionService.submitAnswer(userId, sessionId, request);
+        return ResponseEntity.ok(new ApiResponse<>(true, "답안이 제출되었습니다.", data));
     }
     @PostMapping("/{sessionId}/finish")
     public ResponseEntity<ApiResponse<TestFinishResponseDto>> finishSession(
@@ -85,25 +71,8 @@ public class TestSessionController {
         }
 
         Long userId = (Long) session.getAttribute("LOGIN_USER_ID");
-
-        try {
-            // 2. 비즈니스 로직 실행
-            TestFinishResponseDto data = testSessionService.finishSession(userId, sessionId, request);
-            return ResponseEntity.ok(new ApiResponse<>(true, "테스트가 종료되었습니다.", data));
-
-        } catch (IllegalArgumentException e) {
-            // 3. 에러 핸들링 (400, 403, 404)
-            if (e.getMessage().contains("본인")) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                        .body(new ApiResponse<>(false, e.getMessage(), null));
-            }
-            if (e.getMessage().contains("소요 시간")) {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                        .body(new ApiResponse<>(false, e.getMessage(), null));
-            }
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new ApiResponse<>(false, e.getMessage(), null));
-        }
+        TestFinishResponseDto data = testSessionService.finishSession(userId, sessionId, request);
+        return ResponseEntity.ok(new ApiResponse<>(true, "테스트가 종료되었습니다.", data));
     }
     @GetMapping
     public ResponseEntity<ApiResponse<TestHistoryResponseDto>> getTestHistory(

--- a/src/main/java/com/sw8080/lookeng/controller/WordController.java
+++ b/src/main/java/com/sw8080/lookeng/controller/WordController.java
@@ -41,7 +41,7 @@ public class WordController {
 
         if (!"ADMIN".equals(role)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(new ApiResponse<>(false, "접근 권한이 없습니다.", null));
+                    .body(new ApiResponse<>(false, "관리자 접근 권한이 없습니다.", null));
         }
 
         // 3. 비즈니스 로직 실행
@@ -76,7 +76,7 @@ public class WordController {
 
         if (!"ADMIN".equals(role)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(new ApiResponse<>(false, "접근 권한이 없습니다.", null));
+                    .body(new ApiResponse<>(false, "관리자 접근 권한이 없습니다.", null));
         }
 
         // 4. 비즈니스 로직 실행
@@ -104,7 +104,7 @@ public class WordController {
 
         if (!"ADMIN".equals(role)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(new ApiResponse<>(false, "접근 권한이 없습니다.", null));
+                    .body(new ApiResponse<>(false, "관리자 접근 권한이 없습니다.", null));
         }
 
         // 3. 비즈니스 로직(삭제) 실행

--- a/src/main/java/com/sw8080/lookeng/exception/BadRequestException.java
+++ b/src/main/java/com/sw8080/lookeng/exception/BadRequestException.java
@@ -1,0 +1,9 @@
+package com.sw8080.lookeng.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends BusinessException {
+    public BadRequestException(String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/exception/BusinessException.java
+++ b/src/main/java/com/sw8080/lookeng/exception/BusinessException.java
@@ -1,0 +1,17 @@
+package com.sw8080.lookeng.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BusinessException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    public BusinessException(String message, HttpStatus status) {
+        super(message);
+        this.status = status;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/exception/DuplicateException.java
+++ b/src/main/java/com/sw8080/lookeng/exception/DuplicateException.java
@@ -1,0 +1,9 @@
+package com.sw8080.lookeng.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicateException extends BusinessException {
+    public DuplicateException(String message) {
+        super(message, HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/exception/ForbiddenException.java
+++ b/src/main/java/com/sw8080/lookeng/exception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package com.sw8080.lookeng.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends BusinessException {
+    public ForbiddenException(String message) {
+        super(message, HttpStatus.FORBIDDEN);
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/exception/NotFoundException.java
+++ b/src/main/java/com/sw8080/lookeng/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package com.sw8080.lookeng.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends BusinessException {
+    public NotFoundException(String message) {
+        super(message, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/exception/UnauthorizedException.java
+++ b/src/main/java/com/sw8080/lookeng/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.sw8080.lookeng.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends BusinessException {
+    public UnauthorizedException(String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/service/AuthService.java
+++ b/src/main/java/com/sw8080/lookeng/service/AuthService.java
@@ -1,7 +1,8 @@
 package com.sw8080.lookeng.service;
 
-import com.sw8080.lookeng.DuplicateEmailException;
 import com.sw8080.lookeng.Role;
+import com.sw8080.lookeng.exception.DuplicateException;
+import com.sw8080.lookeng.exception.UnauthorizedException;
 import com.sw8080.lookeng.dto.request.LoginRequestDto;
 import com.sw8080.lookeng.dto.request.SignupRequestDto;
 import com.sw8080.lookeng.dto.response.LoginResponseDto;
@@ -24,7 +25,7 @@ public class AuthService {
     public SignupResponseDto signup(SignupRequestDto request) {
         // 1. 중복 이메일 검증
         if (userRepository.existsByEmail(request.getEmail())) {
-            throw new DuplicateEmailException("이미 사용 중인 이메일입니다.");
+            throw new DuplicateException("이미 사용 중인 이메일입니다.");
         }
 
         // 2. 엔티티 생성 (ERD 반영: password_hash 필드 사용)
@@ -54,7 +55,7 @@ public class AuthService {
         // 2. 비밀번호 검증
         if (!passwordEncoder.matches(request.getPassword(), user.getPasswordHash())) {
             // 보안을 위해 이메일이 틀린 것인지 비번이 틀린 것인지 알 수 없게 동일한 메시지 반환
-            throw new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다.");
+            throw new UnauthorizedException("이메일 또는 비밀번호가 일치하지 않습니다.");
         }
 
         // 3. 명세서에 맞춘 응답 DTO 반환
@@ -70,7 +71,7 @@ public class AuthService {
     public SignupResponseDto adminSignup(SignupRequestDto request) {
         // 1. 중복 이메일 검증
         if (userRepository.existsByEmail(request.getEmail())) {
-            throw new DuplicateEmailException("이미 사용 중인 이메일입니다.");
+            throw new DuplicateException("이미 사용 중인 이메일입니다.");
         }
 
         // 2. 관리자 엔티티 생성 (비밀번호 암호화 동일하게 적용)

--- a/src/main/java/com/sw8080/lookeng/service/TestSessionService.java
+++ b/src/main/java/com/sw8080/lookeng/service/TestSessionService.java
@@ -1,6 +1,9 @@
 package com.sw8080.lookeng.service;
 
 import com.sw8080.lookeng.dto.TestHistoryItemDto;
+import com.sw8080.lookeng.exception.BadRequestException;
+import com.sw8080.lookeng.exception.ForbiddenException;
+import com.sw8080.lookeng.exception.NotFoundException;
 import com.sw8080.lookeng.dto.request.TestAnswerRequestDto;
 import com.sw8080.lookeng.dto.request.TestFinishRequestDto;
 import com.sw8080.lookeng.dto.request.TestSessionRequestDto;
@@ -36,9 +39,13 @@ public class TestSessionService {
 
     public TestSessionResponseDto startSession(Long userId, TestSessionRequestDto request) {
         // 1. 전체 단어 중 랜덤으로 n개 추출
+        if (request.getTotalCount() <= 0 || request.getTotalCount() > 50) {
+            throw new BadRequestException("개수가 잘못되었습니다. (1~50 사이로 입력해주세요)");
+        }
+
         List<Word> allWords = wordRepository.findAll();
         if (allWords.size() < request.getTotalCount()) {
-            throw new IllegalArgumentException("전체 단어 수가 요청한 수보다 적습니다.");
+            throw new BadRequestException("전체 단어 수가 요청한 수보다 적습니다.");
         }
 
         Collections.shuffle(allWords);
@@ -75,15 +82,15 @@ public class TestSessionService {
 
         // 1. 세션 조회 및 권한 검사 (명세서 403, 404 에러 처리)
         TestSession session = testSessionRepository.findById(sessionId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다."));
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 세션입니다."));
 
         if (!session.getUserId().equals(userId)) {
-            throw new IllegalArgumentException("본인의 테스트 세션에만 접근할 수 있습니다.");
+            throw new ForbiddenException("본인의 테스트 세션에만 접근할 수 있습니다.");
         }
 
         // 2. 단어 조회
         Word word = wordRepository.findById(request.getWordId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 단어입니다."));
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 단어입니다."));
 
         // 3. 정답 판정 (대소문자 무시, 앞뒤 공백 제거)
         String trimmedInput = request.getUserInput() != null ? request.getUserInput().trim() : "";
@@ -133,13 +140,13 @@ public class TestSessionService {
     public TestFinishResponseDto finishSession(Long userId, Long sessionId, TestFinishRequestDto request) {
         // 1. 세션 조회 및 권한/유효성 검사
         TestSession session = testSessionRepository.findById(sessionId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다."));
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 세션입니다."));
 
         if (!session.getUserId().equals(userId)) {
-            throw new IllegalArgumentException("본인의 테스트 세션에만 접근할 수 있습니다.");
+            throw new ForbiddenException("본인의 테스트 세션에만 접근할 수 있습니다.");
         }
         if (request.getDurationSec() == null || request.getDurationSec() <= 0) {
-            throw new IllegalArgumentException("올바른 소요 시간을 입력해주세요.");
+            throw new BadRequestException("올바른 소요 시간을 입력해주세요.");
         }
 
         // 2. 세션 종료 정보 업데이트

--- a/src/main/java/com/sw8080/lookeng/service/WordService.java
+++ b/src/main/java/com/sw8080/lookeng/service/WordService.java
@@ -1,6 +1,9 @@
 package com.sw8080.lookeng.service;
 
 import com.sw8080.lookeng.dto.WordItemDto;
+import com.sw8080.lookeng.exception.BadRequestException;
+import com.sw8080.lookeng.exception.DuplicateException;
+import com.sw8080.lookeng.exception.NotFoundException;
 import com.sw8080.lookeng.dto.request.WordCreateRequestDto;
 import com.sw8080.lookeng.dto.response.WordDetailResponseDto;
 import com.sw8080.lookeng.dto.response.WordListResponseDto;
@@ -29,13 +32,12 @@ public class WordService {
     public WordResponseDto createWord(WordCreateRequestDto request) {
         // 1. 단어 개수 50개 제한 로직 추가
         if (wordRepository.count() >= 50) {
-            // 프로젝트 예외 처리 방식에 맞춰 400 Bad Request 또는 적절한 상태 코드로 응답하도록 변경하셔도 됩니다.
-            throw new IllegalStateException("단어장에는 최대 50개의 단어만 추가할 수 있습니다.");
+            throw new BadRequestException("단어장에는 최대 50개의 단어만 추가할 수 있습니다.");
         }
 
         // 2. 명세서 409 에러: 동일 영단어 존재 여부 확인
         if (wordRepository.existsByEnglish(request.getEnglish())) {
-            throw new IllegalStateException("이미 존재하는 영단어입니다.");
+            throw new DuplicateException("이미 존재하는 영단어입니다.");
         }
 
         // 3. 단어 엔티티 생성 및 저장
@@ -56,12 +58,12 @@ public class WordService {
     public WordResponseDto updateWord(Long id, WordUpdateRequestDto request) {
         // 1. 명세서 404 에러: 수정할 단어가 존재하는지 조회
         Word word = wordRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 단어를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
 
         // 2. 명세서 409 에러: 영단어(english) 수정 요청이 들어왔고, 그 값이 기존과 다를 경우 중복 검사
         if (request.getEnglish() != null && !request.getEnglish().equals(word.getEnglish())) {
             if (wordRepository.existsByEnglishAndIdNot(request.getEnglish(), id)) {
-                throw new IllegalStateException("이미 존재하는 영단어입니다."); // GlobalExceptionHandler에서 409 처리
+                throw new DuplicateException("이미 존재하는 영단어입니다.");
             }
         }
 
@@ -82,7 +84,7 @@ public class WordService {
     public void deleteWord(Long id) {
         // 1. 명세서 404 에러: 삭제할 단어가 존재하는지 조회
         Word word = wordRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 단어를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
 
         // 2. 단어 삭제
         wordRepository.delete(word);
@@ -122,7 +124,7 @@ public class WordService {
     public WordDetailResponseDto getWordDetail(Long id, Long userId) {
         // 1. 명세서 404 에러: 조회할 단어가 존재하는지 확인
         Word word = wordRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 단어를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
 
         // 2. 나중에 USER_WORD 테이블이 생기면 연동할 부분 (지금은 임시로 false)
         boolean isMemorized = false;


### PR DESCRIPTION
  ## Summary

  - `exception/` 패키지에 `BusinessException` 기반 커스텀 예외 계층 도입 (BadRequest, Unauthorized, Forbidden, NotFound, Duplicate)
  - `GlobalExceptionHandler`를 `BusinessException` 단일 핸들러로 통합하여 중복 제거
  - 모든 서비스·컨트롤러의 예외를 커스텀 예외로 교체, 기존 `DuplicateEmailException` 삭제
  - 테스트 세션 생성 시 totalCount가 0 이하이거나 50 초과인 경우 500 대신 400 반환

  ## Test plan

  - [x] 회원가입 중복 이메일 → 409 응답 확인
  - [x] 로그인 실패 (이메일/비밀번호 불일치) → 401 응답 확인
  - [x] 테스트 세션 생성 시 totalCount = 0 → 400 응답 + "개수가 잘못되었습니다" 메시지 확인
  - [x] 테스트 세션 생성 시 totalCount = 51 → 400 응답 확인
  - [x] 타인의 세션에 접근 → 403 응답 확인
  - [x] 존재하지 않는 세션 ID 조회 → 404 응답 확인

