### PR TITLE
feat: 관리자 유저 목록 및 특정 유저 테스트 기록 조회 API 개발

### DIFF
--- a/src/main/java/com/sw8080/lookeng/SecurityConfig.java
+++ b/src/main/java/com/sw8080/lookeng/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/**",
                                 "/error",
                                 "/api/v1/words/**",
-                                "/api/v1/test/**", "/api/v1/user/**").permitAll()
+                                "/api/v1/test/**", "/api/v1/user/**",
+                                "/api/v1/admin/**").permitAll()
                         .anyRequest().authenticated()
                 );
         return http.build();

--- a/src/main/java/com/sw8080/lookeng/controller/AdminController.java
+++ b/src/main/java/com/sw8080/lookeng/controller/AdminController.java
@@ -1,0 +1,83 @@
+package com.sw8080.lookeng.controller;
+
+import com.sw8080.lookeng.ApiResponse;
+import com.sw8080.lookeng.dto.response.TestHistoryResponseDto;
+import com.sw8080.lookeng.dto.response.UserListResponseDto;
+import com.sw8080.lookeng.exception.NotFoundException;
+import com.sw8080.lookeng.repository.UserRepository;
+import com.sw8080.lookeng.service.AdminService;
+import com.sw8080.lookeng.service.TestSessionService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final AdminService adminService;
+    private final TestSessionService testSessionService;
+    private final UserRepository userRepository;
+
+    @GetMapping("/users")
+    public ResponseEntity<ApiResponse<UserListResponseDto>> getUsers(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            HttpServletRequest httpRequest) {
+
+        // 1. 로그인 확인
+        HttpSession session = httpRequest.getSession(false);
+        if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponse<>(false, "로그인이 필요합니다.", null));
+        }
+
+        // 2. ADMIN 권한 확인
+        Object roleObj = session.getAttribute("LOGIN_USER_ROLE");
+        String role = roleObj != null ? roleObj.toString() : "";
+        if (!"ADMIN".equals(role)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ApiResponse<>(false, "관리자 접근 권한이 없습니다.", null));
+        }
+
+        // 3. 유저 목록 조회
+        UserListResponseDto data = adminService.getUsers(page, size);
+        return ResponseEntity.ok(new ApiResponse<>(true, "유저 목록 조회 성공", data));
+    }
+
+    @GetMapping("/users/{userId}/test-sessions")
+    public ResponseEntity<ApiResponse<TestHistoryResponseDto>> getUserTestSessions(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            HttpServletRequest httpRequest) {
+
+        // 1. 로그인 확인
+        HttpSession session = httpRequest.getSession(false);
+        if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponse<>(false, "로그인이 필요합니다.", null));
+        }
+
+        // 2. ADMIN 권한 확인
+        Object roleObj = session.getAttribute("LOGIN_USER_ROLE");
+        String role = roleObj != null ? roleObj.toString() : "";
+        if (!"ADMIN".equals(role)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ApiResponse<>(false, "관리자 접근 권한이 없습니다.", null));
+        }
+
+        // 3. 대상 유저 존재 확인
+        if (!userRepository.existsById(userId)) {
+            throw new NotFoundException("해당 유저를 찾을 수 없습니다.");
+        }
+
+        // 4. 기존 서비스 재사용
+        TestHistoryResponseDto data = testSessionService.getTestHistory(userId, page, size);
+        return ResponseEntity.ok(new ApiResponse<>(true, "유저 테스트 기록 조회 성공", data));
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/dto/response/UserItemDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/UserItemDto.java
@@ -1,0 +1,32 @@
+package com.sw8080.lookeng.dto.response;
+
+import com.sw8080.lookeng.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserItemDto {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private String role;
+    private LocalDateTime createdAt;
+
+    public static UserItemDto from(User user) {
+        return UserItemDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .role(user.getRole().name())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/dto/response/UserListResponseDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/UserListResponseDto.java
@@ -1,0 +1,33 @@
+package com.sw8080.lookeng.dto.response;
+
+import com.sw8080.lookeng.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserListResponseDto {
+
+    private List<UserItemDto> content;
+    private long totalElements;
+    private int totalPages;
+    private int currentPage;
+    private int size;
+
+    public static UserListResponseDto from(Page<User> page) {
+        return UserListResponseDto.builder()
+                .content(page.getContent().stream().map(UserItemDto::from).toList())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .currentPage(page.getNumber())
+                .size(page.getSize())
+                .build();
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/service/AdminService.java
+++ b/src/main/java/com/sw8080/lookeng/service/AdminService.java
@@ -1,0 +1,29 @@
+package com.sw8080.lookeng.service;
+
+import com.sw8080.lookeng.dto.response.UserListResponseDto;
+import com.sw8080.lookeng.entity.User;
+import com.sw8080.lookeng.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public UserListResponseDto getUsers(int page, int size) {
+        // 1. 최신 가입순 페이지네이션
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        // 2. 전체 유저 조회
+        Page<User> users = userRepository.findAll(pageable);
+        // 3. 응답 DTO 변환
+        return UserListResponseDto.from(users);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #20
- Closes #21

## 변경 사항
- `GET /api/v1/admin/users` — 관리자 유저 목록 조회 (페이지네이션, createdAt 내림차순)
- `GET /api/v1/admin/users/{userId}/test-sessions` — 관리자가 특정 유저의 테스트 기록 조회
- 두 API 모두 ADMIN 권한 필요 (미로그인 401, USER 403)
- 특정 유저 테스트 기록 조회는 기존 `TestSessionService.getTestHistory()` 재사용

## 추가/수정 파일
| 파일 | 구분 |
|------|------|
| `AdminController.java` | 신규 |
| `AdminService.java` | 신규 |
| `UserItemDto.java` | 신규 |
| `UserListResponseDto.java` | 신규 |
| `SecurityConfig.java` | 수정 (`/api/v1/admin/**` permitAll 추가) |

## 테스트 방법
- 미로그인 상태로 호출 → 401
- USER 계정으로 호출 → 403
- ADMIN 계정으로 `GET /api/v1/admin/users` → 200 + 유저 목록
- ADMIN 계정으로 `GET /api/v1/admin/users/1/test-sessions` → 200 + 테스트 기록
- 존재하지 않는 userId → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)