### PR TITLE
fix: Word 소프트 삭제 시 FK 제약 위반 오류 수정 (#29)

### DIFF
--- a/src/main/java/com/sw8080/lookeng/GlobalExceptionHandler.java
+++ b/src/main/java/com/sw8080/lookeng/GlobalExceptionHandler.java
@@ -23,4 +23,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(e.getStatus())
                 .body(new CommonResponse<>(false, e.getMessage(), null));
     }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse<Void>> handleUnexpectedException(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new CommonResponse<>(false, "서버 오류가 발생했습니다.", null));
+    }
 }

--- a/src/main/java/com/sw8080/lookeng/entity/Word.java
+++ b/src/main/java/com/sw8080/lookeng/entity/Word.java
@@ -5,16 +5,20 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@SQLDelete(sql = "UPDATE word SET is_deleted = true WHERE id = ?")
+@SQLRestriction("is_deleted = false")
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class) // 생성/수정 시간 자동 기록
+@EntityListeners(AuditingEntityListener.class)
 public class Word {
 
     @Id

--- a/src/main/java/com/sw8080/lookeng/repository/WordRepository.java
+++ b/src/main/java/com/sw8080/lookeng/repository/WordRepository.java
@@ -6,17 +6,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WordRepository extends JpaRepository<Word, Long> {
-    // 1. 단어 개수 제한(50개)을 위한 조회 (삭제되지 않은 것만)
-    long countByDeletedFalse();
+    // @SQLRestriction("is_deleted = false") 가 모든 쿼리에 자동 적용되므로
+    // DeletedFalse 조건 없이도 삭제된 단어가 자동 제외됨
 
-    // 2. 단어장 목록 조회용 (삭제되지 않은 것만 페이징해서 가져오기)
-    Page<Word> findAllByDeletedFalse(Pageable pageable);
+    // 409 에러(단어 추가 시 중복) 처리
+    boolean existsByEnglish(String english);
 
-    // 3. 409 에러(단어 추가 시 중복) 처리: 삭제 안 된 단어 중 동일한 영단어가 있는지 확인
-    boolean existsByEnglishAndDeletedFalse(String english);
-
-    // 4. 409 에러(단어 수정 시 중복) 처리: 본인(id) 제외, 삭제 안 된 단어 중 동일한 영단어가 있는지 확인
-    boolean existsByEnglishAndIdNotAndDeletedFalse(String english, Long id);
-
-
+    // 409 에러(단어 수정 시 중복) 처리: 본인(id) 제외
+    boolean existsByEnglishAndIdNot(String english, Long id);
 }

--- a/src/main/java/com/sw8080/lookeng/service/WordService.java
+++ b/src/main/java/com/sw8080/lookeng/service/WordService.java
@@ -30,13 +30,13 @@ public class WordService {
 
     @Transactional
     public WordResponseDto createWord(WordCreateRequestDto request) {
-        // 1. 단어 개수 50개 제한 로직 (💡 수정: 삭제되지 않은 단어 기준)
-        if (wordRepository.countByDeletedFalse() >= 50) {
+        // 1. 단어 개수 50개 제한 로직 (@SQLRestriction으로 삭제된 단어 자동 제외)
+        if (wordRepository.count() >= 50) {
             throw new BadRequestException("단어장에는 최대 50개의 단어만 추가할 수 있습니다.");
         }
 
-        // 2. 명세서 409 에러: 동일 영단어 존재 여부 확인 (💡 수정: 삭제되지 않은 단어 기준)
-        if (wordRepository.existsByEnglishAndDeletedFalse(request.getEnglish())) {
+        // 2. 명세서 409 에러: 동일 영단어 존재 여부 확인 (@SQLRestriction으로 삭제된 단어 자동 제외)
+        if (wordRepository.existsByEnglish(request.getEnglish())) {
             throw new DuplicateException("이미 존재하는 영단어입니다.");
         }
 
@@ -57,14 +57,13 @@ public class WordService {
 
     @Transactional
     public WordResponseDto updateWord(Long id, WordUpdateRequestDto request) {
-        // 1. 명세서 404 에러: 수정할 단어가 존재하는지 조회 (💡 수정: 이미 지워진 단어 필터링)
+        // 1. 명세서 404 에러: 수정할 단어가 존재하는지 조회 (@SQLRestriction으로 삭제된 단어 자동 제외)
         Word word = wordRepository.findById(id)
-                .filter(w -> !w.isDeleted())
                 .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
 
-        // 2. 명세서 409 에러: 영단어(english) 수정 요청이 들어왔고, 그 값이 기존과 다를 경우 중복 검사 (💡 수정)
+        // 2. 명세서 409 에러: 영단어(english) 수정 요청이 들어왔고, 그 값이 기존과 다를 경우 중복 검사
         if (request.getEnglish() != null && !request.getEnglish().equals(word.getEnglish())) {
-            if (wordRepository.existsByEnglishAndIdNotAndDeletedFalse(request.getEnglish(), id)) {
+            if (wordRepository.existsByEnglishAndIdNot(request.getEnglish(), id)) {
                 throw new DuplicateException("이미 존재하는 영단어입니다.");
             }
         }
@@ -84,13 +83,12 @@ public class WordService {
 
     @Transactional
     public void deleteWord(Long id) {
-        // 1. 명세서 404 에러: 삭제할 단어가 존재하는지 조회 (💡 수정: 이미 지워진 단어 필터링)
+        // 1. 명세서 404 에러: 삭제할 단어가 존재하는지 조회 (@SQLRestriction으로 삭제된 단어 자동 제외)
         Word word = wordRepository.findById(id)
-                .filter(w -> !w.isDeleted())
                 .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
 
-        // 2. 단어 삭제 (💡 수정: DB에서 날리지 않고 꼬리표만 달기)
-        word.delete();
+        // 2. 소프트 삭제 — @SQLDelete가 DELETE를 UPDATE word SET is_deleted=true 로 변환
+        wordRepository.delete(word);
     }
 
     @Transactional(readOnly = true)
@@ -104,9 +102,9 @@ public class WordService {
             sort = Sort.by(Sort.Direction.DESC, "english");
         }
 
-        // 2. Pageable 객체 생성 및 DB 조회 (💡 수정: 삭제되지 않은 단어만 가져오기)
+        // 2. Pageable 객체 생성 및 DB 조회 (@SQLRestriction으로 삭제된 단어 자동 제외)
         Pageable pageable = PageRequest.of(page, size, sort);
-        Page<Word> wordPage = wordRepository.findAllByDeletedFalse(pageable);
+        Page<Word> wordPage = wordRepository.findAll(pageable);
 
         // 3. 엔티티(Word) -> DTO 변환
         List<WordItemDto> content = wordPage.getContent().stream()
@@ -126,9 +124,8 @@ public class WordService {
 
     @Transactional(readOnly = true)
     public WordDetailResponseDto getWordDetail(Long id, Long userId) {
-        // 1. 명세서 404 에러: 조회할 단어가 존재하는지 확인 (💡 수정: 이미 지워진 단어 필터링)
+        // 1. 명세서 404 에러: 조회할 단어가 존재하는지 확인 (@SQLRestriction으로 삭제된 단어 자동 제외)
         Word word = wordRepository.findById(id)
-                .filter(w -> !w.isDeleted())
                 .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
 
         // 2. 나중에 USER_WORD 테이블이 생기면 연동할 부분 (지금은 임시로 false)


### PR DESCRIPTION
close #29 
---
Word 엔티티에 @SQLDelete/@SQLRestriction 추가로 물리 삭제를
소프트 삭제(UPDATE is_deleted=true)로 전환.
test_session_words FK 제약 위반 해소.

- Word: @SQLDelete + @SQLRestriction 추가 (User 엔티티와 동일 패턴)
- WordService: wordRepository.delete() 사용, 불필요한 .filter() 제거
- WordRepository: @SQLRestriction 자동 적용으로 DeletedFalse 접미사 메서드 제거
- GlobalExceptionHandler: catch-all 핸들러 추가로 500 에러도 올바른 JSON 포맷 반환


---

- 문제점 : 삭제한 단어를 다시 추가 하는 경우에 해당 단어가 등록되지 않는 문제 발생!