### PR TITLE
✨ feat: USER_WORD 북마크/암기 관련 API 구현 (#33)

### DIFF
--- a/src/main/java/com/sw8080/lookeng/controller/CLAUDE.md
+++ b/src/main/java/com/sw8080/lookeng/controller/CLAUDE.md
@@ -23,6 +23,15 @@
 
 단어 목록 쿼리 파라미터: `page`(기본 0), `size`(기본 20), `sort`(기본 `id,asc` / `english,asc` / `english,desc`)
 
+### UserWordController (`/api/v1/user/words`)
+
+| Method | Path | 설명 | 필요 권한 |
+|--------|------|------|-----------|
+| GET | `/bookmarked` | 북마크 단어 목록 조회 | USER 이상 |
+| GET | `/memorized` | 암기 완료 단어 목록 조회 | USER 이상 |
+| PATCH | `/{wordId}/bookmark` | 북마크 토글 | USER 이상 |
+| PATCH | `/{wordId}/memorize` | 암기 상태 토글 | USER 이상 |
+
 ### TestSessionController (`/api/v1/test/sessions`)
 
 | Method | Path | 설명 | 인증 필요 |

--- a/src/main/java/com/sw8080/lookeng/controller/UserWordController.java
+++ b/src/main/java/com/sw8080/lookeng/controller/UserWordController.java
@@ -1,0 +1,110 @@
+package com.sw8080.lookeng.controller;
+
+import com.sw8080.lookeng.ApiResponse;
+import com.sw8080.lookeng.dto.response.BookmarkResponseDto;
+import com.sw8080.lookeng.dto.response.BookmarkedWordDto;
+import com.sw8080.lookeng.dto.response.MemorizeResponseDto;
+import com.sw8080.lookeng.dto.response.MemorizedWordDto;
+import com.sw8080.lookeng.service.UserWordService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/user/words")
+@RequiredArgsConstructor
+public class UserWordController {
+
+    private final UserWordService userWordService;
+
+    @GetMapping("/bookmarked")
+    public ResponseEntity<ApiResponse<List<BookmarkedWordDto>>> getBookmarkedWords(
+            HttpServletRequest httpRequest) {
+
+        // 1. 인증 확인
+        HttpSession session = httpRequest.getSession(false);
+        if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
+        }
+
+        // 2. 세션에서 userId 추출
+        Long userId = Long.valueOf(session.getAttribute("LOGIN_USER_ID").toString());
+
+        // 3. 비즈니스 로직 실행
+        List<BookmarkedWordDto> data = userWordService.getBookmarkedWords(userId);
+
+        // 4. 200 OK 응답 반환
+        return ResponseEntity.ok(new ApiResponse<>(true, "북마크 단어 목록 조회 성공", data));
+    }
+
+    @GetMapping("/memorized")
+    public ResponseEntity<ApiResponse<List<MemorizedWordDto>>> getMemorizedWords(
+            HttpServletRequest httpRequest) {
+
+        // 1. 인증 확인
+        HttpSession session = httpRequest.getSession(false);
+        if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
+        }
+
+        // 2. 세션에서 userId 추출
+        Long userId = Long.valueOf(session.getAttribute("LOGIN_USER_ID").toString());
+
+        // 3. 비즈니스 로직 실행
+        List<MemorizedWordDto> data = userWordService.getMemorizedWords(userId);
+
+        // 4. 200 OK 응답 반환
+        return ResponseEntity.ok(new ApiResponse<>(true, "암기 완료 단어 목록 조회 성공", data));
+    }
+
+    @PatchMapping("/{wordId}/bookmark")
+    public ResponseEntity<ApiResponse<BookmarkResponseDto>> toggleBookmark(
+            @PathVariable Long wordId,
+            HttpServletRequest httpRequest) {
+
+        // 1. 인증 확인
+        HttpSession session = httpRequest.getSession(false);
+        if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
+        }
+
+        // 2. 세션에서 userId 추출
+        Long userId = Long.valueOf(session.getAttribute("LOGIN_USER_ID").toString());
+
+        // 3. 비즈니스 로직 실행
+        BookmarkResponseDto data = userWordService.toggleBookmark(userId, wordId);
+
+        // 4. 200 OK 응답 반환
+        return ResponseEntity.ok(new ApiResponse<>(true, "북마크 상태가 변경되었습니다.", data));
+    }
+
+    @PatchMapping("/{wordId}/memorize")
+    public ResponseEntity<ApiResponse<MemorizeResponseDto>> toggleMemorize(
+            @PathVariable Long wordId,
+            HttpServletRequest httpRequest) {
+
+        // 1. 인증 확인
+        HttpSession session = httpRequest.getSession(false);
+        if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
+        }
+
+        // 2. 세션에서 userId 추출
+        Long userId = Long.valueOf(session.getAttribute("LOGIN_USER_ID").toString());
+
+        // 3. 비즈니스 로직 실행
+        MemorizeResponseDto data = userWordService.toggleMemorize(userId, wordId);
+
+        // 4. 200 OK 응답 반환
+        return ResponseEntity.ok(new ApiResponse<>(true, "암기 상태가 변경되었습니다.", data));
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/dto/WordItemDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/WordItemDto.java
@@ -14,9 +14,8 @@ public class WordItemDto {
     private String exampleSentence;
     private String pronunciationUrl;
 
-    // 나중에 USER_WORD 테이블이 생기면 연동할 필드
-    private boolean isMemorized;
-    private boolean isBookmarked;
+    private Boolean isMemorized;
+    private Boolean isBookmarked;
 
     public static WordItemDto from(Word word, boolean isMemorized, boolean isBookmarked) {
         return WordItemDto.builder()

--- a/src/main/java/com/sw8080/lookeng/dto/response/BookmarkResponseDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/BookmarkResponseDto.java
@@ -1,0 +1,22 @@
+package com.sw8080.lookeng.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkResponseDto {
+    private Long wordId;
+    private Boolean isBookmarked;
+
+    public static BookmarkResponseDto from(Long wordId, boolean isBookmarked) {
+        return BookmarkResponseDto.builder()
+                .wordId(wordId)
+                .isBookmarked(isBookmarked)
+                .build();
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/dto/response/BookmarkedWordDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/BookmarkedWordDto.java
@@ -1,0 +1,32 @@
+package com.sw8080.lookeng.dto.response;
+
+import com.sw8080.lookeng.entity.UserWord;
+import com.sw8080.lookeng.entity.Word;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookmarkedWordDto {
+    private Long wordId;
+    private String english;
+    private String korean;
+    private String partOfSpeech;
+    private Boolean isMemorized;
+    private Boolean isBookmarked;
+
+    public static BookmarkedWordDto from(Word word, UserWord userWord) {
+        return BookmarkedWordDto.builder()
+                .wordId(word.getId())
+                .english(word.getEnglish())
+                .korean(word.getKorean())
+                .partOfSpeech(word.getPartOfSpeech())
+                .isMemorized(userWord.isMemorized())
+                .isBookmarked(true)
+                .build();
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/dto/response/MemorizeResponseDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/MemorizeResponseDto.java
@@ -1,0 +1,26 @@
+package com.sw8080.lookeng.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemorizeResponseDto {
+    private Long wordId;
+    private Boolean isMemorized;
+    private LocalDateTime memorizedAt;
+
+    public static MemorizeResponseDto from(Long wordId, boolean isMemorized, LocalDateTime memorizedAt) {
+        return MemorizeResponseDto.builder()
+                .wordId(wordId)
+                .isMemorized(isMemorized)
+                .memorizedAt(memorizedAt)
+                .build();
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/dto/response/MemorizedWordDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/MemorizedWordDto.java
@@ -1,0 +1,36 @@
+package com.sw8080.lookeng.dto.response;
+
+import com.sw8080.lookeng.entity.UserWord;
+import com.sw8080.lookeng.entity.Word;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemorizedWordDto {
+    private Long wordId;
+    private String english;
+    private String korean;
+    private String partOfSpeech;
+    private Boolean isMemorized;
+    private LocalDateTime memorizedAt;
+    private Boolean isBookmarked;
+
+    public static MemorizedWordDto from(Word word, UserWord userWord) {
+        return MemorizedWordDto.builder()
+                .wordId(word.getId())
+                .english(word.getEnglish())
+                .korean(word.getKorean())
+                .partOfSpeech(word.getPartOfSpeech())
+                .isMemorized(true)
+                .memorizedAt(userWord.getMemorizedAt())
+                .isBookmarked(userWord.isBookmarked())
+                .build();
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/dto/response/WordDetailResponseDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/WordDetailResponseDto.java
@@ -16,9 +16,8 @@ public class WordDetailResponseDto {
     private String exampleSentence;
     private String pronunciationUrl;
 
-    // 유저별 학습 상태 (임시)
-    private boolean isMemorized;
-    private boolean isBookmarked;
+    private Boolean isMemorized;
+    private Boolean isBookmarked;
 
     // 시간 정보
     private LocalDateTime createdAt;

--- a/src/main/java/com/sw8080/lookeng/entity/CLAUDE.md
+++ b/src/main/java/com/sw8080/lookeng/entity/CLAUDE.md
@@ -24,5 +24,14 @@
 - `testSession`과 `word`를 `@ManyToOne`으로 참조
 - `isCorrect` 필드로 오답 목록 필터링에 사용
 
+### UserWord
+- 테이블: `USER_WORD`
+- `(userId, wordId)` 복합 조건으로 레코드를 식별 (`UserWordRepository.findByUserIdAndWordId`)
+- `isBookmarked`: 북마크 상태, 기본값 `false`
+- `toggleBookmark()` 메서드: `isBookmarked` 반전 — Dirty Checking으로 자동 반영
+- `toggleMemorize()` 메서드: `isMemorized` 반전 + `memorizedAt` 갱신 (`true→false`는 null, `false→true`는 NOW())
+- `@LastModifiedDate` + `@EntityListeners(AuditingEntityListener.class)`로 `updatedAt` 자동 기록
+- User/Word 엔티티와 `@ManyToOne` 관계 없이 `Long` 타입으로 외래키 보관 (기존 패턴 유지)
+
 ### BaseTimeEntity
 - `createdAt`, `updatedAt` 공통 필드 제공 — `TestSession`이 상속

--- a/src/main/java/com/sw8080/lookeng/entity/UserWord.java
+++ b/src/main/java/com/sw8080/lookeng/entity/UserWord.java
@@ -1,0 +1,65 @@
+package com.sw8080.lookeng.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "USER_WORD")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class UserWord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "word_id", nullable = false)
+    private Long wordId;
+
+    @Column(name = "is_bookmarked", nullable = false)
+    private boolean isBookmarked = false;
+
+    @Column(name = "is_memorized", nullable = false)
+    private boolean isMemorized = false;
+
+    @Column(name = "memorized_at")
+    private LocalDateTime memorizedAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public UserWord(Long userId, Long wordId, boolean isBookmarked, boolean isMemorized, LocalDateTime memorizedAt) {
+        this.userId = userId;
+        this.wordId = wordId;
+        this.isBookmarked = isBookmarked;
+        this.isMemorized = isMemorized;
+        this.memorizedAt = memorizedAt;
+    }
+
+    public void toggleBookmark() {
+        this.isBookmarked = !this.isBookmarked;
+    }
+
+    public void toggleMemorize() {
+        if (this.isMemorized) {
+            this.isMemorized = false;
+            this.memorizedAt = null;
+        } else {
+            this.isMemorized = true;
+            this.memorizedAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/repository/UserWordRepository.java
+++ b/src/main/java/com/sw8080/lookeng/repository/UserWordRepository.java
@@ -1,0 +1,14 @@
+package com.sw8080.lookeng.repository;
+
+import com.sw8080.lookeng.entity.UserWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserWordRepository extends JpaRepository<UserWord, Long> {
+    Optional<UserWord> findByUserIdAndWordId(Long userId, Long wordId);
+    List<UserWord> findByUserIdAndIsBookmarkedTrue(Long userId);
+    List<UserWord> findByUserIdAndIsMemorizedTrue(Long userId);
+    List<UserWord> findByUserIdAndWordIdIn(Long userId, List<Long> wordIds);
+}

--- a/src/main/java/com/sw8080/lookeng/service/CLAUDE.md
+++ b/src/main/java/com/sw8080/lookeng/service/CLAUDE.md
@@ -10,7 +10,38 @@
 - **단어 최대 50개 제한**: `createWord`에서 `wordRepository.count() >= 50` 시 `BadRequestException`
 - 수정(`updateWord`): `word.update(...)` 호출 후 별도 save 없이 JPA Dirty Checking으로 반영
 - `english` 필드 수정 시에만 중복 검사 (`existsByEnglishAndIdNot`)
-- 목록 조회의 `isMemorized` / `isBookmarked`는 USER_WORD 테이블 미구현으로 현재 `false` 하드코딩
+- 목록 조회(`getWordList`): 페이지 wordId 목록으로 `userWordRepository.findByUserIdAndWordIdIn()` 일괄 조회 → 맵으로 변환 후 실제 `isMemorized` / `isBookmarked` 반영
+- 상세 조회(`getWordDetail`): `userWordRepository.findByUserIdAndWordId()` 조회 → `Optional.map()` 으로 상태 추출, 레코드 없으면 `false`
+
+## UserWordService
+
+**북마크 단어 목록 조회 (`getBookmarkedWords`)**
+1. `userWordRepository.findByUserIdAndIsBookmarkedTrue(userId)` → 북마크된 UserWord 목록
+2. wordId 목록 추출 → `wordRepository.findAllById(wordIds)` 일괄 조회 (`@SQLRestriction`으로 삭제 단어 자동 제외)
+3. `wordId → UserWord` 맵 생성 (isMemorized 참조용)
+4. `BookmarkedWordDto.from(word, userWord)` 변환 후 반환 (페이지네이션 없음, 최대 50개 보장)
+
+**암기 완료 단어 목록 조회 (`getMemorizedWords`)**
+1. `userWordRepository.findByUserIdAndIsMemorizedTrue(userId)` → 암기 완료된 UserWord 목록
+2. wordId 목록 추출 → `wordRepository.findAllById(wordIds)` 일괄 조회 (`@SQLRestriction`으로 삭제 단어 자동 제외)
+3. `wordId → UserWord` 맵 생성 (isBookmarked, memorizedAt 참조용)
+4. `MemorizedWordDto.from(word, userWord)` 변환 후 반환 (페이지네이션 없음, 최대 50개 보장)
+
+**북마크 토글 (`toggleBookmark`)**
+1. `wordRepository.findById(wordId)` — 존재하지 않으면 `NotFoundException` (404)
+2. `userWordRepository.findByUserIdAndWordId(userId, wordId)` 조회
+3. 레코드 없으면 → `isBookmarked = true`로 신규 생성 후 save
+4. 레코드 있으면 → `userWord.toggleBookmark()` 호출 (Dirty Checking으로 반영)
+5. `BookmarkResponseDto.from(wordId, newState)` 반환
+
+**암기 상태 토글 (`toggleMemorize`)**
+1. `wordRepository.findById(wordId)` — 존재하지 않으면 `NotFoundException` (404)
+2. `userWordRepository.findByUserIdAndWordId(userId, wordId)` 조회
+3. 레코드 없으면 → `isMemorized = true`, `memorizedAt = NOW()`로 신규 생성 후 save
+4. 레코드 있으면 → `userWord.toggleMemorize()` 호출 (Dirty Checking으로 반영)
+   - `true → false`: `memorizedAt = null`
+   - `false → true`: `memorizedAt = LocalDateTime.now()`
+5. `MemorizeResponseDto.from(wordId, newState, memorizedAt)` 반환
 
 ## TestSessionService
 

--- a/src/main/java/com/sw8080/lookeng/service/UserWordService.java
+++ b/src/main/java/com/sw8080/lookeng/service/UserWordService.java
@@ -1,0 +1,138 @@
+package com.sw8080.lookeng.service;
+
+import com.sw8080.lookeng.dto.response.BookmarkResponseDto;
+import com.sw8080.lookeng.dto.response.BookmarkedWordDto;
+import com.sw8080.lookeng.dto.response.MemorizeResponseDto;
+import com.sw8080.lookeng.dto.response.MemorizedWordDto;
+import com.sw8080.lookeng.entity.UserWord;
+import com.sw8080.lookeng.entity.Word;
+import com.sw8080.lookeng.exception.NotFoundException;
+import com.sw8080.lookeng.repository.UserWordRepository;
+import com.sw8080.lookeng.repository.WordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserWordService {
+
+    private final UserWordRepository userWordRepository;
+    private final WordRepository wordRepository;
+
+    @Transactional
+    public BookmarkResponseDto toggleBookmark(Long userId, Long wordId) {
+        // 1. 단어 존재 여부 확인
+        wordRepository.findById(wordId)
+                .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
+
+        // 2. USER_WORD 레코드 조회
+        Optional<UserWord> userWordOpt = userWordRepository.findByUserIdAndWordId(userId, wordId);
+
+        boolean newBookmarkState;
+        if (userWordOpt.isEmpty()) {
+            // 3. 없으면 is_bookmarked = true로 신규 생성
+            UserWord userWord = UserWord.builder()
+                    .userId(userId)
+                    .wordId(wordId)
+                    .isBookmarked(true)
+                    .isMemorized(false)
+                    .memorizedAt(null)
+                    .build();
+            userWordRepository.save(userWord);
+            newBookmarkState = true;
+        } else {
+            // 4. 있으면 is_bookmarked 반전 (Dirty Checking 발동)
+            UserWord userWord = userWordOpt.get();
+            userWord.toggleBookmark();
+            newBookmarkState = userWord.isBookmarked();
+        }
+
+        // 5. 응답 DTO 반환
+        return BookmarkResponseDto.from(wordId, newBookmarkState);
+    }
+
+    @Transactional
+    public MemorizeResponseDto toggleMemorize(Long userId, Long wordId) {
+        // 1. 단어 존재 여부 확인
+        wordRepository.findById(wordId)
+                .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
+
+        // 2. USER_WORD 레코드 조회
+        Optional<UserWord> userWordOpt = userWordRepository.findByUserIdAndWordId(userId, wordId);
+
+        boolean newMemorizedState;
+        LocalDateTime newMemorizedAt;
+        if (userWordOpt.isEmpty()) {
+            // 3. 없으면 is_memorized = true, memorized_at = NOW()로 신규 생성
+            LocalDateTime now = LocalDateTime.now();
+            UserWord userWord = UserWord.builder()
+                    .userId(userId)
+                    .wordId(wordId)
+                    .isBookmarked(false)
+                    .isMemorized(true)
+                    .memorizedAt(now)
+                    .build();
+            userWordRepository.save(userWord);
+            newMemorizedState = true;
+            newMemorizedAt = now;
+        } else {
+            // 4. 있으면 is_memorized 반전, memorized_at 갱신 (Dirty Checking 발동)
+            UserWord userWord = userWordOpt.get();
+            userWord.toggleMemorize();
+            newMemorizedState = userWord.isMemorized();
+            newMemorizedAt = userWord.getMemorizedAt();
+        }
+
+        // 5. 응답 DTO 반환
+        return MemorizeResponseDto.from(wordId, newMemorizedState, newMemorizedAt);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BookmarkedWordDto> getBookmarkedWords(Long userId) {
+        // 1. 해당 유저의 북마크된 USER_WORD 레코드 조회
+        List<UserWord> userWords = userWordRepository.findByUserIdAndIsBookmarkedTrue(userId);
+
+        // 2. wordId 목록 추출 후 Word 일괄 조회 (@SQLRestriction으로 삭제된 단어 자동 제외)
+        List<Long> wordIds = userWords.stream()
+                .map(UserWord::getWordId)
+                .collect(Collectors.toList());
+        List<Word> words = wordRepository.findAllById(wordIds);
+
+        // 3. wordId → UserWord 맵 생성 (isMemorized 참조용)
+        Map<Long, UserWord> userWordMap = userWords.stream()
+                .collect(Collectors.toMap(UserWord::getWordId, uw -> uw));
+
+        // 4. DTO 변환 (삭제된 단어는 words 목록에서 이미 제외됨)
+        return words.stream()
+                .map(word -> BookmarkedWordDto.from(word, userWordMap.get(word.getId())))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemorizedWordDto> getMemorizedWords(Long userId) {
+        // 1. 해당 유저의 암기 완료된 USER_WORD 레코드 조회
+        List<UserWord> userWords = userWordRepository.findByUserIdAndIsMemorizedTrue(userId);
+
+        // 2. wordId 목록 추출 후 Word 일괄 조회 (@SQLRestriction으로 삭제된 단어 자동 제외)
+        List<Long> wordIds = userWords.stream()
+                .map(UserWord::getWordId)
+                .collect(Collectors.toList());
+        List<Word> words = wordRepository.findAllById(wordIds);
+
+        // 3. wordId → UserWord 맵 생성 (isBookmarked, memorizedAt 참조용)
+        Map<Long, UserWord> userWordMap = userWords.stream()
+                .collect(Collectors.toMap(UserWord::getWordId, uw -> uw));
+
+        // 4. DTO 변환 (삭제된 단어는 words 목록에서 이미 제외됨)
+        return words.stream()
+                .map(word -> MemorizedWordDto.from(word, userWordMap.get(word.getId())))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/service/WordService.java
+++ b/src/main/java/com/sw8080/lookeng/service/WordService.java
@@ -9,7 +9,9 @@ import com.sw8080.lookeng.dto.response.WordDetailResponseDto;
 import com.sw8080.lookeng.dto.response.WordListResponseDto;
 import com.sw8080.lookeng.dto.response.WordResponseDto;
 import com.sw8080.lookeng.dto.response.WordUpdateRequestDto;
+import com.sw8080.lookeng.entity.UserWord;
 import com.sw8080.lookeng.entity.Word;
+import com.sw8080.lookeng.repository.UserWordRepository;
 import com.sw8080.lookeng.repository.WordRepository;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -28,6 +31,7 @@ import java.util.stream.Collectors;
 public class WordService {
 
     private final WordRepository wordRepository;
+    private final UserWordRepository userWordRepository;
 
     @Transactional
     public WordResponseDto createWord(WordCreateRequestDto request) {
@@ -118,13 +122,25 @@ public class WordService {
         Pageable pageable = PageRequest.of(page, size, sort);
         Page<Word> wordPage = wordRepository.findAll(pageable);
 
-        // 3. 엔티티(Word) -> DTO 변환
+        // 3. 해당 페이지 wordId 목록으로 USER_WORD 일괄 조회 → wordId 맵 생성
+        List<Long> wordIds = wordPage.getContent().stream()
+                .map(Word::getId)
+                .collect(Collectors.toList());
+        Map<Long, UserWord> userWordMap = userWordRepository.findByUserIdAndWordIdIn(userId, wordIds)
+                .stream()
+                .collect(Collectors.toMap(UserWord::getWordId, uw -> uw));
+
+        // 4. 엔티티(Word) -> DTO 변환
         List<WordItemDto> content = wordPage.getContent().stream()
-                // 지금은 USER_WORD 테이블이 없으므로 임시로 false 꽂아넣기!
-                .map(word -> WordItemDto.from(word, false, false))
+                .map(word -> {
+                    UserWord uw = userWordMap.get(word.getId());
+                    boolean isMemorized = uw != null && uw.isMemorized();
+                    boolean isBookmarked = uw != null && uw.isBookmarked();
+                    return WordItemDto.from(word, isMemorized, isBookmarked);
+                })
                 .collect(Collectors.toList());
 
-        // 4. 명세서 포맷에 맞게 응답 DTO 조립
+        // 5. 명세서 포맷에 맞게 응답 DTO 조립
         return WordListResponseDto.builder()
                 .content(content)
                 .totalElements(wordPage.getTotalElements())
@@ -140,9 +156,10 @@ public class WordService {
         Word word = wordRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
 
-        // 2. 나중에 USER_WORD 테이블이 생기면 연동할 부분 (지금은 임시로 false)
-        boolean isMemorized = false;
-        boolean isBookmarked = false;
+        // 2. USER_WORD 조회로 실제 학습 상태 반영
+        Optional<UserWord> userWordOpt = userWordRepository.findByUserIdAndWordId(userId, id);
+        boolean isMemorized = userWordOpt.map(UserWord::isMemorized).orElse(false);
+        boolean isBookmarked = userWordOpt.map(UserWord::isBookmarked).orElse(false);
 
         // 3. DTO로 변환하여 반환
         return WordDetailResponseDto.from(word, isMemorized, isBookmarked);


### PR DESCRIPTION
- UserWord 엔티티, UserWordRepository, UserWordService, UserWordController 신규 생성
- PATCH /api/v1/user/words/{wordId}/bookmark 북마크 상태 토글
- PATCH /api/v1/user/words/{wordId}/memorize 암기 완료 상태 토글
- GET /api/v1/user/words/bookmarked 북마크 단어 목록 조회
- GET /api/v1/user/words/memorized 암기 완료 단어 목록 조회
- WordService 단어 목록/상세 조회 시 실제 북마크/암기 상태 반영
- DTO boolean 필드 Jackson 직렬화 버그 수정 (Boolean 타입으로 변경)
- CLAUDE.md 업데이트 (controller, service, entity)