### PR TITLE
feat: CSV 단어 일괄 추가 API 구현

### DIFF
--- a/src/main/java/com/sw8080/lookeng/controller/WordController.java
+++ b/src/main/java/com/sw8080/lookeng/controller/WordController.java
@@ -2,6 +2,7 @@ package com.sw8080.lookeng.controller;
 
 import com.sw8080.lookeng.ApiResponse;
 import com.sw8080.lookeng.dto.request.WordCreateRequestDto;
+import com.sw8080.lookeng.dto.response.BulkUploadResponseDto;
 import com.sw8080.lookeng.dto.response.WordDetailResponseDto;
 import com.sw8080.lookeng.dto.response.WordListResponseDto;
 import com.sw8080.lookeng.dto.response.WordResponseDto;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/words")
@@ -35,7 +37,6 @@ public class WordController {
         }
 
         // 2. 명세서 403 에러: ADMIN 권한 확인
-        // 주의: 세션에 저장된 Role이 Enum인 경우 문자열 변환 처리
         Object roleObj = session.getAttribute("LOGIN_USER_ROLE");
         String role = roleObj != null ? roleObj.toString() : "";
 
@@ -51,6 +52,42 @@ public class WordController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new ApiResponse<>(true, "단어가 추가되었습니다.", data));
     }
+
+    @PostMapping("/bulk")
+    public ResponseEntity<ApiResponse<BulkUploadResponseDto>> bulkUpload(
+            @RequestParam("file") MultipartFile file,
+            HttpServletRequest httpRequest) {
+
+        // 1. 명세서 401 에러: 인증(로그인) 확인
+        HttpSession session = httpRequest.getSession(false);
+        if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
+        }
+
+        // 2. 명세서 403 에러: ADMIN 권한 확인
+        Object roleObj = session.getAttribute("LOGIN_USER_ROLE");
+        String role = roleObj != null ? roleObj.toString() : "";
+
+        if (!"ADMIN".equals(role)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ApiResponse<>(false, "관리자 접근 권한이 없습니다.", null));
+        }
+
+        // 3. 파일 누락 확인
+        if (file == null || file.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponse<>(false, "파일을 선택해주세요.", null));
+        }
+
+        // 4. 비즈니스 로직 실행
+        BulkUploadResponseDto data = wordService.bulkUpload(file);
+
+        // 5. 명세서 201 Created 응답 반환
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ApiResponse<>(true, "단어 일괄 추가가 완료되었습니다.", data));
+    }
+
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<WordResponseDto>> updateWord(
             @PathVariable Long id,
@@ -70,7 +107,7 @@ public class WordController {
                     .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
         }
 
-        // 3. 명세서 403 에러: ADMIN 권한 확인 (현우님과 상의 전까지 임시 주석 처리 가능)
+        // 3. 명세서 403 에러: ADMIN 권한 확인
         Object roleObj = session.getAttribute("LOGIN_USER_ROLE");
         String role = roleObj != null ? roleObj.toString() : "";
 
@@ -98,7 +135,7 @@ public class WordController {
                     .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
         }
 
-        // 2. 명세서 403 에러: ADMIN 권한 확인 (테스트 중이라면 임시 주석 처리!)
+        // 2. 명세서 403 에러: ADMIN 권한 확인
         Object roleObj = session.getAttribute("LOGIN_USER_ROLE");
         String role = roleObj != null ? roleObj.toString() : "";
 
@@ -161,5 +198,4 @@ public class WordController {
         // 4. 명세서 200 OK 응답 반환
         return ResponseEntity.ok(new ApiResponse<>(true, "단어 상세 조회 성공", data));
     }
-
 }

--- a/src/main/java/com/sw8080/lookeng/dto/response/BulkUploadResponseDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/BulkUploadResponseDto.java
@@ -1,0 +1,12 @@
+package com.sw8080.lookeng.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BulkUploadResponseDto {
+    private int totalRequested;
+    private int successCount;
+    private int failCount;
+}

--- a/src/main/java/com/sw8080/lookeng/repository/WordRepository.java
+++ b/src/main/java/com/sw8080/lookeng/repository/WordRepository.java
@@ -1,12 +1,11 @@
 package com.sw8080.lookeng.repository;
 
 import com.sw8080.lookeng.entity.Word;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface WordRepository extends JpaRepository<Word, Long> {
@@ -22,4 +21,8 @@ public interface WordRepository extends JpaRepository<Word, Long> {
     // @SQLRestriction을 무시하고 삭제된 데이터까지 포함해서 조회
     @Query(value = "SELECT * FROM word w WHERE w.english = :english", nativeQuery = true)
     Optional<Word> findByEnglishIncludingDeleted(@Param("english") String english);
+
+    // CSV 일괄 업로드 시 DB 중복 영단어 일괄 조회 (루프 대신 쿼리 1번으로 처리)
+    @Query("SELECT w.english FROM Word w WHERE w.english IN :englishList")
+    List<String> findExistingEnglish(@Param("englishList") List<String> englishList);
 }

--- a/src/main/java/com/sw8080/lookeng/service/WordService.java
+++ b/src/main/java/com/sw8080/lookeng/service/WordService.java
@@ -1,6 +1,7 @@
 package com.sw8080.lookeng.service;
 
 import com.sw8080.lookeng.dto.WordItemDto;
+import com.sw8080.lookeng.dto.response.BulkUploadResponseDto;
 import com.sw8080.lookeng.exception.BadRequestException;
 import com.sw8080.lookeng.exception.DuplicateException;
 import com.sw8080.lookeng.exception.NotFoundException;
@@ -20,10 +21,18 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -32,6 +41,10 @@ public class WordService {
 
     private final WordRepository wordRepository;
     private final UserWordRepository userWordRepository;
+
+    // CSV 헤더 포맷 상수
+    private static final String CSV_HEADER = "english,korean,partOfSpeech,exampleSentence,pronunciationUrl";
+    private static final int MAX_BULK_COUNT = 1000;
 
     @Transactional
     public WordResponseDto createWord(WordCreateRequestDto request) {
@@ -72,12 +85,118 @@ public class WordService {
     }
 
     @Transactional
+    public BulkUploadResponseDto bulkUpload(MultipartFile file) {
+        // 1. 확장자 검증 (.csv만 허용)
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !originalFilename.toLowerCase().endsWith(".csv")) {
+            throw new BadRequestException("CSV 파일만 업로드 가능합니다.");
+        }
+
+        // 2. CSV 파싱 및 행별 유효성 검사
+        List<WordCreateRequestDto> validWords = new ArrayList<>();
+        Set<String> seenEnglish = new HashSet<>(); // CSV 내부 중복 검사용
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8))) {
+
+            // 3. 헤더 검증
+            String headerLine = reader.readLine();
+            if (headerLine == null) {
+                throw new BadRequestException("파일이 비어 있습니다.");
+            }
+            if (!headerLine.trim().equals(CSV_HEADER)) {
+                throw new BadRequestException("CSV 헤더가 올바르지 않습니다. 예상: " + CSV_HEADER);
+            }
+
+            // 4. 행별 파싱
+            String line;
+            int rowNum = 1;
+            while ((line = reader.readLine()) != null) {
+                rowNum++;
+                if (line.isBlank()) continue;
+
+                // 1000행 초과 검사
+                if (validWords.size() >= MAX_BULK_COUNT) {
+                    throw new BadRequestException("한 번에 최대 " + MAX_BULK_COUNT + "개의 단어만 업로드 가능합니다.");
+                }
+
+                String[] cols = parseCsvLine(line);
+                String english = cols.length > 0 ? cols[0].trim() : "";
+                String korean  = cols.length > 1 ? cols[1].trim() : "";
+
+                // 필수값 검증
+                if (english.isEmpty()) {
+                    throw new BadRequestException(rowNum + "행: 영단어(english)는 필수입니다.");
+                }
+                if (korean.isEmpty()) {
+                    throw new BadRequestException(rowNum + "행: 뜻(korean)은 필수입니다.");
+                }
+
+                // CSV 내 중복 검사
+                if (!seenEnglish.add(english.toLowerCase())) {
+                    throw new DuplicateException(rowNum + "행: CSV 내 중복 영단어 '" + english + "'가 있습니다.");
+                }
+
+                String partOfSpeech    = cols.length > 2 ? emptyToNull(cols[2]) : null;
+                String exampleSentence = cols.length > 3 ? emptyToNull(cols[3]) : null;
+                String pronunciationUrl = cols.length > 4 ? emptyToNull(cols[4]) : null;
+
+                validWords.add(new WordCreateRequestDto(
+                        english, korean, partOfSpeech, exampleSentence, pronunciationUrl));
+            }
+
+        } catch (IOException e) {
+            throw new BadRequestException("파일을 읽는 중 오류가 발생했습니다.");
+        }
+
+        if (validWords.isEmpty()) {
+            throw new BadRequestException("업로드할 단어가 없습니다.");
+        }
+
+        // 5. DB 중복 일괄 검사 (루프 대신 쿼리 1번으로 처리)
+        List<String> englishList = validWords.stream()
+                .map(WordCreateRequestDto::getEnglish)
+                .collect(Collectors.toList());
+        List<String> duplicates = wordRepository.findExistingEnglish(englishList);
+        if (!duplicates.isEmpty()) {
+            throw new DuplicateException("이미 등록된 영단어가 포함되어 있습니다: " + String.join(", ", duplicates));
+        }
+
+        // 6. 단어 개수 50개 제한 확인
+        long currentCount = wordRepository.count();
+        if (currentCount + validWords.size() > 50) {
+            throw new BadRequestException(
+                    "단어장 최대 개수(50개)를 초과합니다. 현재 " + currentCount + "개, 추가 요청 " + validWords.size() + "개");
+        }
+
+        // 7. 일괄 저장
+        List<Word> words = validWords.stream()
+                .map(dto -> Word.builder()
+                        .english(dto.getEnglish())
+                        .korean(dto.getKorean())
+                        .partOfSpeech(dto.getPartOfSpeech())
+                        .exampleSentence(dto.getExampleSentence())
+                        .pronunciationUrl(dto.getPronunciationUrl())
+                        .build())
+                .collect(Collectors.toList());
+
+        wordRepository.saveAll(words);
+
+        int count = validWords.size();
+        return BulkUploadResponseDto.builder()
+                .totalRequested(count)
+                .successCount(count)
+                .failCount(0)
+                .build();
+    }
+
+    @Transactional
     public WordResponseDto updateWord(Long id, WordUpdateRequestDto request) {
-        // 1. 명세서 404 에러: 수정할 단어가 존재하는지 조회 (@SQLRestriction으로 삭제된 단어 자동 제외)
+        // 1. 명세서 404 에러: 수정할 단어가 존재하는지 조회
         Word word = wordRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
 
-        // 2. 명세서 409 에러: 영단어(english) 수정 요청이 들어왔고, 그 값이 기존과 다를 경우 중복 검사
+        // 2. 명세서 409 에러: 영단어(english) 수정 요청 시 중복 검사
         if (request.getEnglish() != null && !request.getEnglish().equals(word.getEnglish())) {
             if (wordRepository.existsByEnglishAndIdNot(request.getEnglish(), id)) {
                 throw new DuplicateException("이미 존재하는 영단어입니다.");
@@ -99,7 +218,7 @@ public class WordService {
 
     @Transactional
     public void deleteWord(Long id) {
-        // 1. 명세서 404 에러: 삭제할 단어가 존재하는지 조회 (@SQLRestriction으로 삭제된 단어 자동 제외)
+        // 1. 명세서 404 에러: 삭제할 단어가 존재하는지 조회
         Word word = wordRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
 
@@ -110,19 +229,19 @@ public class WordService {
     @Transactional(readOnly = true)
     public WordListResponseDto getWordList(int page, int size, String sortParam, Long userId) {
 
-        // 1. 명세서에 따른 정렬(Sort) 조건 파싱
-        Sort sort = Sort.by(Sort.Direction.ASC, "id"); // 기본값: id,asc
+        // 1. 정렬 조건 파싱
+        Sort sort = Sort.by(Sort.Direction.ASC, "id");
         if ("english,asc".equals(sortParam)) {
             sort = Sort.by(Sort.Direction.ASC, "english");
         } else if ("english,desc".equals(sortParam)) {
             sort = Sort.by(Sort.Direction.DESC, "english");
         }
 
-        // 2. Pageable 객체 생성 및 DB 조회 (@SQLRestriction으로 삭제된 단어 자동 제외)
+        // 2. Pageable 객체 생성 및 DB 조회
         Pageable pageable = PageRequest.of(page, size, sort);
         Page<Word> wordPage = wordRepository.findAll(pageable);
 
-        // 3. 해당 페이지 wordId 목록으로 USER_WORD 일괄 조회 → wordId 맵 생성
+        // 3. 해당 페이지 wordId 목록으로 USER_WORD 일괄 조회
         List<Long> wordIds = wordPage.getContent().stream()
                 .map(Word::getId)
                 .collect(Collectors.toList());
@@ -140,7 +259,7 @@ public class WordService {
                 })
                 .collect(Collectors.toList());
 
-        // 5. 명세서 포맷에 맞게 응답 DTO 조립
+        // 5. 응답 DTO 조립
         return WordListResponseDto.builder()
                 .content(content)
                 .totalElements(wordPage.getTotalElements())
@@ -152,7 +271,7 @@ public class WordService {
 
     @Transactional(readOnly = true)
     public WordDetailResponseDto getWordDetail(Long id, Long userId) {
-        // 1. 명세서 404 에러: 조회할 단어가 존재하는지 확인 (@SQLRestriction으로 삭제된 단어 자동 제외)
+        // 1. 명세서 404 에러: 조회할 단어가 존재하는지 확인
         Word word = wordRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
 
@@ -163,5 +282,33 @@ public class WordService {
 
         // 3. DTO로 변환하여 반환
         return WordDetailResponseDto.from(word, isMemorized, isBookmarked);
+    }
+
+    // ── CSV 파싱 헬퍼 ──────────────────────────────────────────────────────────
+
+    // 따옴표로 감싼 필드(쉼표 포함 가능)를 처리하는 CSV 라인 파서
+    private String[] parseCsvLine(String line) {
+        List<String> fields = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+
+        for (char c : line.toCharArray()) {
+            if (c == '"') {
+                inQuotes = !inQuotes;
+            } else if (c == ',' && !inQuotes) {
+                fields.add(current.toString());
+                current = new StringBuilder();
+            } else {
+                current.append(c);
+            }
+        }
+        fields.add(current.toString());
+        return fields.toArray(new String[0]);
+    }
+
+    // 빈 문자열을 null로 변환 (선택 필드 처리용)
+    private String emptyToNull(String value) {
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=LookEng
+# CSV 업로드 파일 크기 제한 (5MB 초과 시 Spring이 자동으로 413 응답)
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB


### PR DESCRIPTION
## 관련 이슈
Closes #37

## 작업 내용
- BulkUploadResponseDto 생성
- WordRepository에 findExistingEnglish() 추가
- WordController에 POST /api/v1/words/bulk 엔드포인트 추가
- WordService에 bulkUpload() 구현 (파싱/검증/일괄저장)
- application.properties에 multipart 파일 크기 제한 추가