### PR TITLE
feat: 단어 검색 API 구현

### DIFF
--- a/src/main/java/com/sw8080/lookeng/controller/WordController.java
+++ b/src/main/java/com/sw8080/lookeng/controller/WordController.java
@@ -6,6 +6,7 @@ import com.sw8080.lookeng.dto.response.BulkUploadResponseDto;
 import com.sw8080.lookeng.dto.response.WordDetailResponseDto;
 import com.sw8080.lookeng.dto.response.WordListResponseDto;
 import com.sw8080.lookeng.dto.response.WordResponseDto;
+import com.sw8080.lookeng.dto.response.WordSearchResponseDto;
 import com.sw8080.lookeng.dto.response.WordUpdateRequestDto;
 import com.sw8080.lookeng.service.WordService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,17 +30,16 @@ public class WordController {
             @Valid @RequestBody WordCreateRequestDto request,
             HttpServletRequest httpRequest) {
 
-        // 1. 명세서 401 에러: 인증(로그인) 확인
+        // 1. 인증 확인
         HttpSession session = httpRequest.getSession(false);
         if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
         }
 
-        // 2. 명세서 403 에러: ADMIN 권한 확인
+        // 2. ADMIN 권한 확인
         Object roleObj = session.getAttribute("LOGIN_USER_ROLE");
         String role = roleObj != null ? roleObj.toString() : "";
-
         if (!"ADMIN".equals(role)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body(new ApiResponse<>(false, "관리자 접근 권한이 없습니다.", null));
@@ -48,7 +48,6 @@ public class WordController {
         // 3. 비즈니스 로직 실행
         WordResponseDto data = wordService.createWord(request);
 
-        // 4. 명세서 201 Created 응답 반환
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new ApiResponse<>(true, "단어가 추가되었습니다.", data));
     }
@@ -58,17 +57,16 @@ public class WordController {
             @RequestParam("file") MultipartFile file,
             HttpServletRequest httpRequest) {
 
-        // 1. 명세서 401 에러: 인증(로그인) 확인
+        // 1. 인증 확인
         HttpSession session = httpRequest.getSession(false);
         if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
         }
 
-        // 2. 명세서 403 에러: ADMIN 권한 확인
+        // 2. ADMIN 권한 확인
         Object roleObj = session.getAttribute("LOGIN_USER_ROLE");
         String role = roleObj != null ? roleObj.toString() : "";
-
         if (!"ADMIN".equals(role)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body(new ApiResponse<>(false, "관리자 접근 권한이 없습니다.", null));
@@ -83,9 +81,38 @@ public class WordController {
         // 4. 비즈니스 로직 실행
         BulkUploadResponseDto data = wordService.bulkUpload(file);
 
-        // 5. 명세서 201 Created 응답 반환
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new ApiResponse<>(true, "단어 일괄 추가가 완료되었습니다.", data));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<WordSearchResponseDto>> searchWords(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            HttpServletRequest httpRequest) {
+
+        // 1. 인증 확인
+        HttpSession session = httpRequest.getSession(false);
+        if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
+        }
+
+        // 2. keyword 누락 확인
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponse<>(false, "검색어를 입력해주세요.", null));
+        }
+
+        // 3. 세션에서 userId 추출
+        Object userIdObj = session.getAttribute("LOGIN_USER_ID");
+        Long userId = Long.valueOf(userIdObj.toString());
+
+        // 4. 비즈니스 로직 실행 (USER / ADMIN 모두 가능)
+        WordSearchResponseDto data = wordService.searchWords(keyword, page, size, userId);
+
+        return ResponseEntity.ok(new ApiResponse<>(true, "단어 검색 결과를 성공적으로 조회했습니다.", data));
     }
 
     @PatchMapping("/{id}")
@@ -94,23 +121,22 @@ public class WordController {
             @Valid @RequestBody WordUpdateRequestDto request,
             HttpServletRequest httpRequest) {
 
-        // 1. 명세서 400 에러: 아무것도 변경하지 않는 빈 요청 필터링
+        // 1. 빈 요청 필터링
         if (request.isEmpty()) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(new ApiResponse<>(false, "수정할 항목을 최소 1개 이상 입력해주세요.", null));
         }
 
-        // 2. 명세서 401 에러: 인증(로그인) 확인
+        // 2. 인증 확인
         HttpSession session = httpRequest.getSession(false);
         if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
         }
 
-        // 3. 명세서 403 에러: ADMIN 권한 확인
+        // 3. ADMIN 권한 확인
         Object roleObj = session.getAttribute("LOGIN_USER_ROLE");
         String role = roleObj != null ? roleObj.toString() : "";
-
         if (!"ADMIN".equals(role)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body(new ApiResponse<>(false, "관리자 접근 권한이 없습니다.", null));
@@ -119,7 +145,6 @@ public class WordController {
         // 4. 비즈니스 로직 실행
         WordResponseDto data = wordService.updateWord(id, request);
 
-        // 5. 명세서 200 OK 응답 반환
         return ResponseEntity.ok(new ApiResponse<>(true, "단어가 수정되었습니다.", data));
     }
 
@@ -128,26 +153,24 @@ public class WordController {
             @PathVariable Long id,
             HttpServletRequest httpRequest) {
 
-        // 1. 명세서 401 에러: 인증(로그인) 확인
+        // 1. 인증 확인
         HttpSession session = httpRequest.getSession(false);
         if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
         }
 
-        // 2. 명세서 403 에러: ADMIN 권한 확인
+        // 2. ADMIN 권한 확인
         Object roleObj = session.getAttribute("LOGIN_USER_ROLE");
         String role = roleObj != null ? roleObj.toString() : "";
-
         if (!"ADMIN".equals(role)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body(new ApiResponse<>(false, "관리자 접근 권한이 없습니다.", null));
         }
 
-        // 3. 비즈니스 로직(삭제) 실행
+        // 3. 비즈니스 로직 실행
         wordService.deleteWord(id);
 
-        // 4. 명세서 200 OK 응답 반환
         return ResponseEntity.ok(new ApiResponse<>(true, "단어가 삭제되었습니다.", null));
     }
 
@@ -158,21 +181,20 @@ public class WordController {
             @RequestParam(defaultValue = "id,asc") String sort,
             HttpServletRequest httpRequest) {
 
-        // 1. 명세서 401 에러: 인증(로그인) 확인
+        // 1. 인증 확인
         HttpSession session = httpRequest.getSession(false);
         if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
         }
 
-        // 2. 세션에서 현재 로그인한 유저 ID 꺼내기 (추후 isMemorized 조회용)
+        // 2. userId 추출
         Object userIdObj = session.getAttribute("LOGIN_USER_ID");
         Long userId = Long.valueOf(userIdObj.toString());
 
-        // 3. 비즈니스 로직 실행 (권한 검사 생략 - USER, ADMIN 모두 가능)
+        // 3. 비즈니스 로직 실행
         WordListResponseDto data = wordService.getWordList(page, size, sort, userId);
 
-        // 4. 명세서 200 OK 응답 반환
         return ResponseEntity.ok(new ApiResponse<>(true, "단어 목록 조회 성공", data));
     }
 
@@ -181,21 +203,20 @@ public class WordController {
             @PathVariable Long id,
             HttpServletRequest httpRequest) {
 
-        // 1. 명세서 401 에러: 인증(로그인) 확인
+        // 1. 인증 확인
         HttpSession session = httpRequest.getSession(false);
         if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(new ApiResponse<>(false, "로그인이 필요한 서비스입니다.", null));
         }
 
-        // 2. 세션에서 로그인한 유저 ID 꺼내기
+        // 2. userId 추출
         Object userIdObj = session.getAttribute("LOGIN_USER_ID");
         Long userId = Long.valueOf(userIdObj.toString());
 
         // 3. 비즈니스 로직 실행
         WordDetailResponseDto data = wordService.getWordDetail(id, userId);
 
-        // 4. 명세서 200 OK 응답 반환
         return ResponseEntity.ok(new ApiResponse<>(true, "단어 상세 조회 성공", data));
     }
 }

--- a/src/main/java/com/sw8080/lookeng/dto/response/WordSearchResponseDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/WordSearchResponseDto.java
@@ -1,0 +1,24 @@
+package com.sw8080.lookeng.dto.response;
+
+import com.sw8080.lookeng.dto.WordItemDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class WordSearchResponseDto {
+
+    private List<WordItemDto> content;
+    private PageInfo pageInfo;
+
+    @Getter
+    @Builder
+    public static class PageInfo {
+        private int page;
+        private int size;
+        private long totalElements;
+        private int totalPages;
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/repository/WordRepository.java
+++ b/src/main/java/com/sw8080/lookeng/repository/WordRepository.java
@@ -1,6 +1,8 @@
 package com.sw8080.lookeng.repository;
 
 import com.sw8080.lookeng.entity.Word;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,4 +27,10 @@ public interface WordRepository extends JpaRepository<Word, Long> {
     // CSV 일괄 업로드 시 DB 중복 영단어 일괄 조회 (루프 대신 쿼리 1번으로 처리)
     @Query("SELECT w.english FROM Word w WHERE w.english IN :englishList")
     List<String> findExistingEnglish(@Param("englishList") List<String> englishList);
+
+    // 영단어(english) 또는 한글 뜻(korean) 부분 일치 검색 (대소문자 무시)
+    @Query("SELECT w FROM Word w WHERE " +
+           "LOWER(w.english) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+           "w.korean LIKE CONCAT('%', :keyword, '%')")
+    Page<Word> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/sw8080/lookeng/service/WordService.java
+++ b/src/main/java/com/sw8080/lookeng/service/WordService.java
@@ -2,6 +2,7 @@ package com.sw8080.lookeng.service;
 
 import com.sw8080.lookeng.dto.WordItemDto;
 import com.sw8080.lookeng.dto.response.BulkUploadResponseDto;
+import com.sw8080.lookeng.dto.response.WordSearchResponseDto;
 import com.sw8080.lookeng.exception.BadRequestException;
 import com.sw8080.lookeng.exception.DuplicateException;
 import com.sw8080.lookeng.exception.NotFoundException;
@@ -42,13 +43,12 @@ public class WordService {
     private final WordRepository wordRepository;
     private final UserWordRepository userWordRepository;
 
-    // CSV 헤더 포맷 상수
     private static final String CSV_HEADER = "english,korean,partOfSpeech,exampleSentence,pronunciationUrl";
     private static final int MAX_BULK_COUNT = 1000;
 
     @Transactional
     public WordResponseDto createWord(WordCreateRequestDto request) {
-        // 1. 단어 개수 50개 제한 로직 (@SQLRestriction으로 삭제된 단어 자동 제외)
+        // 1. 단어 개수 50개 제한
         if (wordRepository.count() >= 50) {
             throw new BadRequestException("단어장에는 최대 50개의 단어만 추가할 수 있습니다.");
         }
@@ -58,13 +58,9 @@ public class WordService {
 
         if (existingWord.isPresent()) {
             Word word = existingWord.get();
-
-            // 이미 사용 중인 단어라면 중복 에러 발생
             if (!word.isDeleted()) {
                 throw new DuplicateException("이미 존재하는 영단어입니다.");
             }
-
-            // 삭제된 단어라면 상태를 변경하고 새로운 정보로 업데이트 (Restore)
             word.restore(request);
             return WordResponseDto.from(word);
         }
@@ -86,7 +82,7 @@ public class WordService {
 
     @Transactional
     public BulkUploadResponseDto bulkUpload(MultipartFile file) {
-        // 1. 확장자 검증 (.csv만 허용)
+        // 1. 확장자 검증
         String originalFilename = file.getOriginalFilename();
         if (originalFilename == null || !originalFilename.toLowerCase().endsWith(".csv")) {
             throw new BadRequestException("CSV 파일만 업로드 가능합니다.");
@@ -94,7 +90,7 @@ public class WordService {
 
         // 2. CSV 파싱 및 행별 유효성 검사
         List<WordCreateRequestDto> validWords = new ArrayList<>();
-        Set<String> seenEnglish = new HashSet<>(); // CSV 내부 중복 검사용
+        Set<String> seenEnglish = new HashSet<>();
 
         try (BufferedReader reader = new BufferedReader(
                 new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8))) {
@@ -115,7 +111,6 @@ public class WordService {
                 rowNum++;
                 if (line.isBlank()) continue;
 
-                // 1000행 초과 검사
                 if (validWords.size() >= MAX_BULK_COUNT) {
                     throw new BadRequestException("한 번에 최대 " + MAX_BULK_COUNT + "개의 단어만 업로드 가능합니다.");
                 }
@@ -124,7 +119,6 @@ public class WordService {
                 String english = cols.length > 0 ? cols[0].trim() : "";
                 String korean  = cols.length > 1 ? cols[1].trim() : "";
 
-                // 필수값 검증
                 if (english.isEmpty()) {
                     throw new BadRequestException(rowNum + "행: 영단어(english)는 필수입니다.");
                 }
@@ -132,7 +126,6 @@ public class WordService {
                     throw new BadRequestException(rowNum + "행: 뜻(korean)은 필수입니다.");
                 }
 
-                // CSV 내 중복 검사
                 if (!seenEnglish.add(english.toLowerCase())) {
                     throw new DuplicateException(rowNum + "행: CSV 내 중복 영단어 '" + english + "'가 있습니다.");
                 }
@@ -153,7 +146,7 @@ public class WordService {
             throw new BadRequestException("업로드할 단어가 없습니다.");
         }
 
-        // 5. DB 중복 일괄 검사 (루프 대신 쿼리 1번으로 처리)
+        // 5. DB 중복 일괄 검사
         List<String> englishList = validWords.stream()
                 .map(WordCreateRequestDto::getEnglish)
                 .collect(Collectors.toList());
@@ -190,58 +183,20 @@ public class WordService {
                 .build();
     }
 
-    @Transactional
-    public WordResponseDto updateWord(Long id, WordUpdateRequestDto request) {
-        // 1. 명세서 404 에러: 수정할 단어가 존재하는지 조회
-        Word word = wordRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
-
-        // 2. 명세서 409 에러: 영단어(english) 수정 요청 시 중복 검사
-        if (request.getEnglish() != null && !request.getEnglish().equals(word.getEnglish())) {
-            if (wordRepository.existsByEnglishAndIdNot(request.getEnglish(), id)) {
-                throw new DuplicateException("이미 존재하는 영단어입니다.");
-            }
-        }
-
-        // 3. 단어 정보 수정 (Dirty Checking 발동)
-        word.update(
-                request.getEnglish(),
-                request.getKorean(),
-                request.getPartOfSpeech(),
-                request.getExampleSentence(),
-                request.getPronunciationUrl()
-        );
-
-        // 4. 응답 DTO 변환 후 반환
-        return WordResponseDto.from(word);
-    }
-
-    @Transactional
-    public void deleteWord(Long id) {
-        // 1. 명세서 404 에러: 삭제할 단어가 존재하는지 조회
-        Word word = wordRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
-
-        // 2. 소프트 삭제 — @SQLDelete가 DELETE를 UPDATE word SET is_deleted=true 로 변환
-        wordRepository.delete(word);
-    }
-
     @Transactional(readOnly = true)
-    public WordListResponseDto getWordList(int page, int size, String sortParam, Long userId) {
-
-        // 1. 정렬 조건 파싱
-        Sort sort = Sort.by(Sort.Direction.ASC, "id");
-        if ("english,asc".equals(sortParam)) {
-            sort = Sort.by(Sort.Direction.ASC, "english");
-        } else if ("english,desc".equals(sortParam)) {
-            sort = Sort.by(Sort.Direction.DESC, "english");
+    public WordSearchResponseDto searchWords(String keyword, int page, int size, Long userId) {
+        // 1. 키워드 유효성 검사
+        if (keyword == null || keyword.trim().isEmpty()) {
+            throw new BadRequestException("검색어를 입력해주세요.");
         }
 
-        // 2. Pageable 객체 생성 및 DB 조회
-        Pageable pageable = PageRequest.of(page, size, sort);
-        Page<Word> wordPage = wordRepository.findAll(pageable);
+        // 2. 페이지네이션 설정
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "english"));
 
-        // 3. 해당 페이지 wordId 목록으로 USER_WORD 일괄 조회
+        // 3. DB 검색 (영단어 또는 한글 뜻 부분 일치, 대소문자 무시)
+        Page<Word> wordPage = wordRepository.searchByKeyword(keyword.trim(), pageable);
+
+        // 4. USER_WORD 조회로 isMemorized / isBookmarked 반영
         List<Long> wordIds = wordPage.getContent().stream()
                 .map(Word::getId)
                 .collect(Collectors.toList());
@@ -249,7 +204,7 @@ public class WordService {
                 .stream()
                 .collect(Collectors.toMap(UserWord::getWordId, uw -> uw));
 
-        // 4. 엔티티(Word) -> DTO 변환
+        // 5. 엔티티 → DTO 변환
         List<WordItemDto> content = wordPage.getContent().stream()
                 .map(word -> {
                     UserWord uw = userWordMap.get(word.getId());
@@ -259,7 +214,83 @@ public class WordService {
                 })
                 .collect(Collectors.toList());
 
-        // 5. 응답 DTO 조립
+        // 6. 응답 DTO 조립
+        return WordSearchResponseDto.builder()
+                .content(content)
+                .pageInfo(WordSearchResponseDto.PageInfo.builder()
+                        .page(wordPage.getNumber())
+                        .size(wordPage.getSize())
+                        .totalElements(wordPage.getTotalElements())
+                        .totalPages(wordPage.getTotalPages())
+                        .build())
+                .build();
+    }
+
+    @Transactional
+    public WordResponseDto updateWord(Long id, WordUpdateRequestDto request) {
+        // 1. 수정할 단어 조회
+        Word word = wordRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
+
+        // 2. 영단어 중복 검사
+        if (request.getEnglish() != null && !request.getEnglish().equals(word.getEnglish())) {
+            if (wordRepository.existsByEnglishAndIdNot(request.getEnglish(), id)) {
+                throw new DuplicateException("이미 존재하는 영단어입니다.");
+            }
+        }
+
+        // 3. 단어 정보 수정
+        word.update(
+                request.getEnglish(),
+                request.getKorean(),
+                request.getPartOfSpeech(),
+                request.getExampleSentence(),
+                request.getPronunciationUrl()
+        );
+
+        return WordResponseDto.from(word);
+    }
+
+    @Transactional
+    public void deleteWord(Long id) {
+        Word word = wordRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
+
+        wordRepository.delete(word);
+    }
+
+    @Transactional(readOnly = true)
+    public WordListResponseDto getWordList(int page, int size, String sortParam, Long userId) {
+        // 1. 정렬 조건 파싱
+        Sort sort = Sort.by(Sort.Direction.ASC, "id");
+        if ("english,asc".equals(sortParam)) {
+            sort = Sort.by(Sort.Direction.ASC, "english");
+        } else if ("english,desc".equals(sortParam)) {
+            sort = Sort.by(Sort.Direction.DESC, "english");
+        }
+
+        // 2. DB 조회
+        Pageable pageable = PageRequest.of(page, size, sort);
+        Page<Word> wordPage = wordRepository.findAll(pageable);
+
+        // 3. USER_WORD 일괄 조회
+        List<Long> wordIds = wordPage.getContent().stream()
+                .map(Word::getId)
+                .collect(Collectors.toList());
+        Map<Long, UserWord> userWordMap = userWordRepository.findByUserIdAndWordIdIn(userId, wordIds)
+                .stream()
+                .collect(Collectors.toMap(UserWord::getWordId, uw -> uw));
+
+        // 4. DTO 변환
+        List<WordItemDto> content = wordPage.getContent().stream()
+                .map(word -> {
+                    UserWord uw = userWordMap.get(word.getId());
+                    boolean isMemorized = uw != null && uw.isMemorized();
+                    boolean isBookmarked = uw != null && uw.isBookmarked();
+                    return WordItemDto.from(word, isMemorized, isBookmarked);
+                })
+                .collect(Collectors.toList());
+
         return WordListResponseDto.builder()
                 .content(content)
                 .totalElements(wordPage.getTotalElements())
@@ -271,22 +302,18 @@ public class WordService {
 
     @Transactional(readOnly = true)
     public WordDetailResponseDto getWordDetail(Long id, Long userId) {
-        // 1. 명세서 404 에러: 조회할 단어가 존재하는지 확인
         Word word = wordRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("해당 단어를 찾을 수 없습니다."));
 
-        // 2. USER_WORD 조회로 실제 학습 상태 반영
         Optional<UserWord> userWordOpt = userWordRepository.findByUserIdAndWordId(userId, id);
         boolean isMemorized = userWordOpt.map(UserWord::isMemorized).orElse(false);
         boolean isBookmarked = userWordOpt.map(UserWord::isBookmarked).orElse(false);
 
-        // 3. DTO로 변환하여 반환
         return WordDetailResponseDto.from(word, isMemorized, isBookmarked);
     }
 
     // ── CSV 파싱 헬퍼 ──────────────────────────────────────────────────────────
 
-    // 따옴표로 감싼 필드(쉼표 포함 가능)를 처리하는 CSV 라인 파서
     private String[] parseCsvLine(String line) {
         List<String> fields = new ArrayList<>();
         StringBuilder current = new StringBuilder();
@@ -306,7 +333,6 @@ public class WordService {
         return fields.toArray(new String[0]);
     }
 
-    // 빈 문자열을 null로 변환 (선택 필드 처리용)
     private String emptyToNull(String value) {
         String trimmed = value.trim();
         return trimmed.isEmpty() ? null : trimmed;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,6 @@ lookeng:
   admin:
     secret-code: "LOOKENG_SECRET_777"
 
-
 ---
 spring:
   config:
@@ -37,6 +36,17 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB
+
+server:
+  servlet:
+    session:
+      cookie:
+        same-site: none
+        secure: false
 
 logging:
   level:


### PR DESCRIPTION
WordSearchResponseDto 생성
- WordRepository에 searchByKeyword() 추가
- WordController에 GET /api/v1/words/search 엔드포인트 추가
- WordService에 searchWords() 구현 (부분 일치, 대소문자 무시, 페이지네이션)