### PR TITLE
🐛 fix: 북마크/암기완료 단어 목록 API 응답에 예문 누락 수정 (#45)

### DIFF
--- a/src/main/java/com/sw8080/lookeng/dto/response/BookmarkedWordDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/BookmarkedWordDto.java
@@ -16,6 +16,7 @@ public class BookmarkedWordDto {
     private String english;
     private String korean;
     private String partOfSpeech;
+    private String exampleSentence;
     private Boolean isMemorized;
     private Boolean isBookmarked;
 
@@ -25,6 +26,7 @@ public class BookmarkedWordDto {
                 .english(word.getEnglish())
                 .korean(word.getKorean())
                 .partOfSpeech(word.getPartOfSpeech())
+                .exampleSentence(word.getExampleSentence())
                 .isMemorized(userWord.isMemorized())
                 .isBookmarked(true)
                 .build();

--- a/src/main/java/com/sw8080/lookeng/dto/response/MemorizedWordDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/MemorizedWordDto.java
@@ -18,6 +18,7 @@ public class MemorizedWordDto {
     private String english;
     private String korean;
     private String partOfSpeech;
+    private String exampleSentence;
     private Boolean isMemorized;
     private LocalDateTime memorizedAt;
     private Boolean isBookmarked;
@@ -28,6 +29,7 @@ public class MemorizedWordDto {
                 .english(word.getEnglish())
                 .korean(word.getKorean())
                 .partOfSpeech(word.getPartOfSpeech())
+                .exampleSentence(word.getExampleSentence())
                 .isMemorized(true)
                 .memorizedAt(userWord.getMemorizedAt())
                 .isBookmarked(userWord.isBookmarked())


### PR DESCRIPTION
BookmarkedWordDto, MemorizedWordDto에 exampleSentence 필드 추가