### PR TITLE
fix: CSV 업로드 시 소프트딜리트된 단어 복구 처리

### DIFF
--- a/src/main/java/com/sw8080/lookeng/repository/WordRepository.java
+++ b/src/main/java/com/sw8080/lookeng/repository/WordRepository.java
@@ -20,11 +20,15 @@ public interface WordRepository extends JpaRepository<Word, Long> {
     // 409 에러(단어 수정 시 중복) 처리: 본인(id) 제외
     boolean existsByEnglishAndIdNot(String english, Long id);
 
-    // @SQLRestriction을 무시하고 삭제된 데이터까지 포함해서 조회
+    // @SQLRestriction을 무시하고 삭제된 데이터까지 포함해서 단건 조회
     @Query(value = "SELECT * FROM word w WHERE w.english = :english", nativeQuery = true)
     Optional<Word> findByEnglishIncludingDeleted(@Param("english") String english);
 
-    // CSV 일괄 업로드 시 DB 중복 영단어 일괄 조회 (루프 대신 쿼리 1번으로 처리)
+    // CSV 일괄 업로드 시 삭제된 단어 포함 일괄 조회 (restore 처리용)
+    @Query(value = "SELECT * FROM word w WHERE w.english IN :englishList", nativeQuery = true)
+    List<Word> findAllByEnglishIncludingDeleted(@Param("englishList") List<String> englishList);
+
+    // CSV 일괄 업로드 시 활성화된 단어 중복 일괄 조회
     @Query("SELECT w.english FROM Word w WHERE w.english IN :englishList")
     List<String> findExistingEnglish(@Param("englishList") List<String> englishList);
 

--- a/src/main/java/com/sw8080/lookeng/service/WordService.java
+++ b/src/main/java/com/sw8080/lookeng/service/WordService.java
@@ -130,8 +130,8 @@ public class WordService {
                     throw new DuplicateException(rowNum + "행: CSV 내 중복 영단어 '" + english + "'가 있습니다.");
                 }
 
-                String partOfSpeech    = cols.length > 2 ? emptyToNull(cols[2]) : null;
-                String exampleSentence = cols.length > 3 ? emptyToNull(cols[3]) : null;
+                String partOfSpeech     = cols.length > 2 ? emptyToNull(cols[2]) : null;
+                String exampleSentence  = cols.length > 3 ? emptyToNull(cols[3]) : null;
                 String pronunciationUrl = cols.length > 4 ? emptyToNull(cols[4]) : null;
 
                 validWords.add(new WordCreateRequestDto(
@@ -146,38 +146,58 @@ public class WordService {
             throw new BadRequestException("업로드할 단어가 없습니다.");
         }
 
-        // 5. DB 중복 일괄 검사
+        // 5. 삭제된 단어 포함 일괄 조회
         List<String> englishList = validWords.stream()
                 .map(WordCreateRequestDto::getEnglish)
                 .collect(Collectors.toList());
-        List<String> duplicates = wordRepository.findExistingEnglish(englishList);
-        if (!duplicates.isEmpty()) {
-            throw new DuplicateException("이미 등록된 영단어가 포함되어 있습니다: " + String.join(", ", duplicates));
+        List<Word> existingWords = wordRepository.findAllByEnglishIncludingDeleted(englishList);
+
+        // 5-1. 활성화된 단어(중복) vs 소프트딜리트된 단어(복구 가능) 분리
+        Map<String, Word> existingMap = existingWords.stream()
+                .collect(Collectors.toMap(Word::getEnglish, w -> w));
+
+        List<String> activeDuplicates = existingWords.stream()
+                .filter(w -> !w.isDeleted())
+                .map(Word::getEnglish)
+                .collect(Collectors.toList());
+
+        if (!activeDuplicates.isEmpty()) {
+            throw new DuplicateException("이미 등록된 영단어가 포함되어 있습니다: " + String.join(", ", activeDuplicates));
         }
 
-        // 6. 단어 개수 50개 제한 확인
-        long currentCount = wordRepository.count();
-        if (currentCount + validWords.size() > 50) {
+        // 6. 단어 개수 50개 제한 확인 (소프트딜리트 복구는 카운트 제외)
+        long activeCount = wordRepository.count();
+        long newWordCount = validWords.stream()
+                .filter(dto -> !existingMap.containsKey(dto.getEnglish()))
+                .count();
+        if (activeCount + newWordCount > 50) {
             throw new BadRequestException(
-                    "단어장 최대 개수(50개)를 초과합니다. 현재 " + currentCount + "개, 추가 요청 " + validWords.size() + "개");
+                    "단어장 최대 개수(50개)를 초과합니다. 현재 " + activeCount + "개, 신규 추가 " + newWordCount + "개");
         }
 
-        // 7. 일괄 저장
-        List<Word> words = validWords.stream()
-                .map(dto -> Word.builder()
+        // 7. 소프트딜리트된 단어 복구 + 새 단어 저장
+        int count = 0;
+        for (WordCreateRequestDto dto : validWords) {
+            Word existing = existingMap.get(dto.getEnglish());
+            if (existing != null && existing.isDeleted()) {
+                // 소프트딜리트된 단어 복구
+                existing.restore(dto);
+                count++;
+            } else {
+                // 새 단어 생성
+                wordRepository.save(Word.builder()
                         .english(dto.getEnglish())
                         .korean(dto.getKorean())
                         .partOfSpeech(dto.getPartOfSpeech())
                         .exampleSentence(dto.getExampleSentence())
                         .pronunciationUrl(dto.getPronunciationUrl())
-                        .build())
-                .collect(Collectors.toList());
+                        .build());
+                count++;
+            }
+        }
 
-        wordRepository.saveAll(words);
-
-        int count = validWords.size();
         return BulkUploadResponseDto.builder()
-                .totalRequested(count)
+                .totalRequested(validWords.size())
                 .successCount(count)
                 .failCount(0)
                 .build();


### PR DESCRIPTION
기존의 csv 추가가 소프트 delete된 단어를 인식하지 못하여 csv 단어 추가시 기존의 소프트 딜리트된 단어를 딜리트 안된 상태로 되돌리고 csv입력을 기반으로 수정하는 방식으로 수정