### PR TITLE
✨ feat: 진도율/등급 조회 API 계산 로직 변경 (#51)

### DIFF
--- a/src/main/java/com/sw8080/lookeng/dto/response/ProgressResponseDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/ProgressResponseDto.java
@@ -13,14 +13,14 @@ public class ProgressResponseDto {
 
     private int level;
     private long totalWords;
-    private long masteredWords;
+    private long memorizedWords;
     private long wordsToNextLevel;
 
-    public static ProgressResponseDto from(int level, long totalWords, long masteredWords, long wordsToNextLevel) {
+    public static ProgressResponseDto from(int level, long totalWords, long memorizedWords, long wordsToNextLevel) {
         return ProgressResponseDto.builder()
                 .level(level)
                 .totalWords(totalWords)
-                .masteredWords(masteredWords)
+                .memorizedWords(memorizedWords)
                 .wordsToNextLevel(wordsToNextLevel)
                 .build();
     }

--- a/src/main/java/com/sw8080/lookeng/repository/UserWordRepository.java
+++ b/src/main/java/com/sw8080/lookeng/repository/UserWordRepository.java
@@ -11,4 +11,5 @@ public interface UserWordRepository extends JpaRepository<UserWord, Long> {
     List<UserWord> findByUserIdAndIsBookmarkedTrue(Long userId);
     List<UserWord> findByUserIdAndIsMemorizedTrue(Long userId);
     List<UserWord> findByUserIdAndWordIdIn(Long userId, List<Long> wordIds);
+    long countByUserIdAndIsMemorizedTrue(Long userId);
 }

--- a/src/main/java/com/sw8080/lookeng/service/ProgressService.java
+++ b/src/main/java/com/sw8080/lookeng/service/ProgressService.java
@@ -1,7 +1,7 @@
 package com.sw8080.lookeng.service;
 
 import com.sw8080.lookeng.dto.response.ProgressResponseDto;
-import com.sw8080.lookeng.repository.TestAnswerRepository;
+import com.sw8080.lookeng.repository.UserWordRepository;
 import com.sw8080.lookeng.repository.WordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,25 +12,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProgressService {
 
     private final WordRepository wordRepository;
-    private final TestAnswerRepository testAnswerRepository;
+    private final UserWordRepository userWordRepository;
 
     @Transactional(readOnly = true)
     public ProgressResponseDto getProgress(Long userId) {
         // 1. 전체 단어 수 조회
         long totalWords = wordRepository.count();
 
-        // 2. 학습 완료 단어 수 조회 (퀴즈에서 정답을 맞힌 고유 단어 개수)
-        long masteredWords = testAnswerRepository.countDistinctCorrectWordsByUserId(userId);
+        // 2. 암기 완료 단어 수 조회 (isMemorized = true 기준)
+        long memorizedWords = userWordRepository.countByUserIdAndIsMemorizedTrue(userId);
 
         // 3. 레벨 및 다음 레벨까지 남은 개수 계산
-        int level = calculateLevel(masteredWords);
-        long wordsToNextLevel = calculateWordsToNextLevel(level, masteredWords);
+        int level = calculateLevel(memorizedWords);
+        long wordsToNextLevel = calculateWordsToNextLevel(level, memorizedWords);
 
         // 4. 응답 DTO 변환
-        return ProgressResponseDto.from(level, totalWords, masteredWords, wordsToNextLevel);
+        return ProgressResponseDto.from(level, totalWords, memorizedWords, wordsToNextLevel);
     }
 
-    // 5. 레벨 계산 로직
     private int calculateLevel(long count) {
         if (count >= 40) {
             return 5;
@@ -47,7 +46,6 @@ public class ProgressService {
         return 1;
     }
 
-    // 6. 다음 레벨까지 남은 단어 수 계산 로직
     private long calculateWordsToNextLevel(int currentLevel, long count) {
         if (currentLevel >= 5) {
             return 0;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ spring:
       on-profile: dev
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
   servlet:
     multipart:


### PR DESCRIPTION
## 개요
진도율/등급 조회 API(`GET /api/v1/user/progress`)의 계산 기준을
기존 TestAnswer 정답 기반에서 `USER_WORD.isMemorized` 기반으로 변경합니다.

Closes #51

---

## 변경 사항

### ✨ feat
- `ProgressService`: 암기 완료 단어 수 계산 기준을 `TestAnswer` 정답 이력 → `UserWord.isMemorized = true` 기준으로 변경
- `UserWordRepository`: `countByUserIdAndIsMemorizedTrue(Long userId)` 메서드 추가
- `ProgressResponseDto`: 응답 필드명 `masteredWords` → `memorizedWords` 변경

### 🔧 chore
- `application.yml`: dev 프로필 `ddl-auto` `create-drop` → `update` 변경 (서버 재시작 시 데이터 유지)

---

## API 명세

**GET** `/api/v1/user/progress`

**응답**
```json
{
  "success": true,
  "message": "진도율 조회를 성공했습니다.",
  "data": {
    "level": 2,
    "totalWords": 50,
    "memorizedWords": 15,
    "wordsToNextLevel": 5
  }
}
```