### PR TITLE
✨ feat: 퀴즈 유형 확장 (4지선다 / 예문 빈칸) #52

### DIFF
--- a/src/main/java/com/sw8080/lookeng/dto/response/TestSessionResponseDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/TestSessionResponseDto.java
@@ -1,8 +1,11 @@
 package com.sw8080.lookeng.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sw8080.lookeng.entity.QuizType;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -15,10 +18,13 @@ public class TestSessionResponseDto {
 
     @Getter
     @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class QuestionDto {
         private Long wordId;
         private String korean;
         private String partOfSpeech;
         private String exampleSentence;
+        private String sentence;         // FILL_IN_BLANK: 빈칸 처리된 예문
+        private List<String> choices;    // MULTIPLE_CHOICE / FILL_IN_BLANK: 4지선다 보기
     }
 }

--- a/src/main/java/com/sw8080/lookeng/entity/QuizType.java
+++ b/src/main/java/com/sw8080/lookeng/entity/QuizType.java
@@ -1,5 +1,5 @@
 package com.sw8080.lookeng.entity;
 
 public enum QuizType {
-    SHORT_ANSWER, MULTIPLE_CHOICE
+    SHORT_ANSWER, MULTIPLE_CHOICE, FILL_IN_BLANK
 }

--- a/src/main/java/com/sw8080/lookeng/service/TestSessionService.java
+++ b/src/main/java/com/sw8080/lookeng/service/TestSessionService.java
@@ -25,8 +25,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,20 +41,34 @@ public class TestSessionService {
     private final TestAnswerRepository testAnswerRepository;
 
     public TestSessionResponseDto startSession(Long userId, TestSessionRequestDto request) {
-        // 1. 전체 단어 중 랜덤으로 n개 추출
+        // 1. totalCount 유효성 검사
         if (request.getTotalCount() <= 0 || request.getTotalCount() > 50) {
             throw new BadRequestException("개수가 잘못되었습니다. (1~50 사이로 입력해주세요)");
         }
 
         List<Word> allWords = wordRepository.findAll();
-        if (allWords.size() < request.getTotalCount()) {
-            throw new BadRequestException("전체 단어 수가 요청한 수보다 적습니다.");
+
+        // 2. FILL_IN_BLANK: 예문 있는 단어만 출제 가능
+        List<Word> candidateWords;
+        if (request.getQuizType() == com.sw8080.lookeng.entity.QuizType.FILL_IN_BLANK) {
+            candidateWords = allWords.stream()
+                    .filter(w -> w.getExampleSentence() != null && !w.getExampleSentence().isBlank())
+                    .collect(Collectors.toList());
+            if (candidateWords.size() < request.getTotalCount()) {
+                throw new BadRequestException("예문이 있는 단어 수가 요청한 수보다 적습니다.");
+            }
+        } else {
+            candidateWords = allWords;
+            if (candidateWords.size() < request.getTotalCount()) {
+                throw new BadRequestException("전체 단어 수가 요청한 수보다 적습니다.");
+            }
         }
 
-        Collections.shuffle(allWords);
-        List<Word> selectedWords = allWords.subList(0, request.getTotalCount());
+        // 3. 랜덤 추출
+        Collections.shuffle(candidateWords);
+        List<Word> selectedWords = new ArrayList<>(candidateWords.subList(0, request.getTotalCount()));
 
-        // 2. 세션 생성 및 저장
+        // 4. 세션 생성 및 저장
         TestSession session = TestSession.builder()
                 .userId(userId)
                 .quizType(request.getQuizType())
@@ -62,19 +79,14 @@ public class TestSessionService {
 
         testSessionRepository.save(session);
 
-        // 3. 첫 번째 문제 정보 조립
+        // 5. 첫 번째 문제 조립
         Word firstWord = selectedWords.get(0);
         return TestSessionResponseDto.builder()
                 .sessionId(session.getId())
                 .quizType(session.getQuizType())
                 .totalCount(session.getTotalCount())
                 .currentIndex(0)
-                .question(TestSessionResponseDto.QuestionDto.builder()
-                        .wordId(firstWord.getId())
-                        .korean(firstWord.getKorean())
-                        .partOfSpeech(firstWord.getPartOfSpeech())
-                        .exampleSentence(firstWord.getExampleSentence())
-                        .build())
+                .question(buildQuestionDto(firstWord, session.getQuizType(), selectedWords))
                 .build();
     }
     @Transactional
@@ -123,12 +135,7 @@ public class TestSessionService {
 
         if (!isFinished) {
             Word nextWord = session.getWords().get(session.getCurrentIndex());
-            nextQuestion = TestSessionResponseDto.QuestionDto.builder()
-                    .wordId(nextWord.getId())
-                    .korean(nextWord.getKorean())
-                    .partOfSpeech(nextWord.getPartOfSpeech())
-                    .exampleSentence(nextWord.getExampleSentence())
-                    .build();
+            nextQuestion = buildQuestionDto(nextWord, session.getQuizType(), session.getWords());
         }
 
         // 7. 응답 조립
@@ -196,6 +203,65 @@ public class TestSessionService {
                 .wrongWords(wrongWords)
                 .build();
     }
+    private TestSessionResponseDto.QuestionDto buildQuestionDto(
+            Word word, com.sw8080.lookeng.entity.QuizType quizType, List<Word> pool) {
+
+        return switch (quizType) {
+            case MULTIPLE_CHOICE -> TestSessionResponseDto.QuestionDto.builder()
+                    .wordId(word.getId())
+                    .korean(word.getKorean())
+                    .partOfSpeech(word.getPartOfSpeech())
+                    .choices(generateChoices(word, pool))
+                    .build();
+            case FILL_IN_BLANK -> TestSessionResponseDto.QuestionDto.builder()
+                    .wordId(word.getId())
+                    .sentence(blankSentence(word.getEnglish(), word.getExampleSentence()))
+                    .choices(generateChoices(word, pool))
+                    .build();
+            default -> TestSessionResponseDto.QuestionDto.builder()
+                    .wordId(word.getId())
+                    .korean(word.getKorean())
+                    .partOfSpeech(word.getPartOfSpeech())
+                    .exampleSentence(word.getExampleSentence())
+                    .build();
+        };
+    }
+
+    private List<String> generateChoices(Word correct, List<Word> pool) {
+        // 1. 풀에서 정답 제외한 오답 후보 목록 구성
+        List<String> distractors = pool.stream()
+                .filter(w -> !w.getId().equals(correct.getId()))
+                .map(Word::getEnglish)
+                .collect(Collectors.toList());
+        Collections.shuffle(distractors);
+
+        // 2. 오답이 3개 미만이면 DB 전체에서 보충
+        if (distractors.size() < 3) {
+            List<String> allEnglish = wordRepository.findAll().stream()
+                    .filter(w -> !w.getId().equals(correct.getId()))
+                    .map(Word::getEnglish)
+                    .collect(Collectors.toList());
+            Collections.shuffle(allEnglish);
+            for (String e : allEnglish) {
+                if (!distractors.contains(e)) {
+                    distractors.add(e);
+                }
+                if (distractors.size() == 3) break;
+            }
+        }
+
+        // 3. 정답 포함 4지선다 조합 후 셔플
+        List<String> choices = new ArrayList<>(distractors.subList(0, Math.min(3, distractors.size())));
+        choices.add(correct.getEnglish());
+        Collections.shuffle(choices);
+        return choices;
+    }
+
+    private String blankSentence(String english, String exampleSentence) {
+        return exampleSentence.replaceAll(
+                "(?i)\\b" + Pattern.quote(english) + "\\b", "_____");
+    }
+
     @Transactional(readOnly = true)
     public TestHistoryResponseDto getTestHistory(Long userId, int page, int size) {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ spring:
       on-profile: dev
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
   servlet:
     multipart:


### PR DESCRIPTION
## 관련 이슈
Closes #52

## 변경 개요

기존 `SHORT_ANSWER` 단일 퀴즈 유형에서 **`MULTIPLE_CHOICE`(4지선다)** 와 **`FILL_IN_BLANK`(예문 빈칸)** 를 추가합니다.

---

## 변경 사항

### `QuizType.java`
- `FILL_IN_BLANK` enum 값 추가

### `TestSessionResponseDto.QuestionDto`
- `sentence` 필드 추가 — FILL_IN_BLANK용 빈칸 처리된 예문
- `choices` 필드 추가 — MULTIPLE_CHOICE / FILL_IN_BLANK용 4지선다 보기 (List\<String\>)
- `@JsonInclude(NON_NULL)` 적용 — 사용하지 않는 필드는 응답 JSON에서 자동 제외

### `TestSessionService`
- **`startSession`** — quizType별 분기 처리
  - `FILL_IN_BLANK`: `exampleSentence != null`인 단어만 후보로 필터, 부족 시 400 반환
  - `MULTIPLE_CHOICE` / `FILL_IN_BLANK`: `generateChoices()`로 4지선다 생성
- **`buildQuestionDto(word, quizType, pool)`** — 퀴즈 유형별 QuestionDto 조립
  - `SHORT_ANSWER` → korean / partOfSpeech / exampleSentence
  - `MULTIPLE_CHOICE` → korean / partOfSpeech / choices
  - `FILL_IN_BLANK` → sentence(빈칸 예문) / choices
- **`generateChoices(correct, pool)`** — 세션 단어 풀에서 오답 3개 랜덤 추출 + 정답 포함 셔플. 풀 부족 시 DB 전체에서 보충
- **`blankSentence(english, exampleSentence)`** — 정규식으로 정답 단어를 `_____`로 치환
- **`submitAnswer`** — nextQuestion 조립도 `buildQuestionDto`로 통일

### `application.yml` (dev 프로필)
- `ddl-auto: create-drop` → `update` 변경 (서버 재시작 시 데이터 유지)

---

## 퀴즈 유형별 응답 구조

| quizType | 응답 필드 |
|----------|-----------|
| `SHORT_ANSWER` | wordId, korean, partOfSpeech, exampleSentence |
| `MULTIPLE_CHOICE` | wordId, korean, partOfSpeech, choices |
| `FILL_IN_BLANK` | wordId, sentence, choices |

---

## 에러 처리

| 상태코드 | 상황 |
|----------|------|
| `400` | totalCount ≤ 0 또는 전체 단어 수 초과 |
| `400` | FILL_IN_BLANK 선택 시 예문 있는 단어가 totalCount보다 부족 |
| `400` | 유효하지 않은 quizType 값 |
| `401` | 미로그인 |
