### PR TITLE
🐛 fix: SHORT_ANSWER 예문에서 정답 단어 마스킹 처리 (#54)

### DIFF
--- a/src/main/java/com/sw8080/lookeng/service/TestSessionService.java
+++ b/src/main/java/com/sw8080/lookeng/service/TestSessionService.java
@@ -222,7 +222,7 @@ public class TestSessionService {
                     .wordId(word.getId())
                     .korean(word.getKorean())
                     .partOfSpeech(word.getPartOfSpeech())
-                    .exampleSentence(word.getExampleSentence())
+                    .exampleSentence(maskWord(word.getEnglish(), word.getExampleSentence()))
                     .build();
         };
     }
@@ -260,6 +260,12 @@ public class TestSessionService {
     private String blankSentence(String english, String exampleSentence) {
         return exampleSentence.replaceAll(
                 "(?i)\\b" + Pattern.quote(english) + "\\b", "_____");
+    }
+
+    private String maskWord(String english, String exampleSentence) {
+        if (exampleSentence == null) return null;
+        String mask = "_".repeat(english.length());
+        return exampleSentence.replaceAll("(?i)\\b" + Pattern.quote(english) + "\\b", mask);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 관련 이슈
closes #54

## 변경 사항
`TestSessionService.buildQuestionDto`의 SHORT_ANSWER 케이스에서 `exampleSentence`를 그대로 반환하던 부분을 수정했습니다.

**추가된 메서드 — `maskWord`**
- 정답 단어를 글자 수만큼 `_`로 치환 (예: `abandon` → `_______`)
- 대소문자 무관 치환 (`(?i)`)
- 예문이 `null`인 단어도 안전하게 처리

**적용 범위**
- `POST /api/v1/test/sessions` (세션 시작) — 첫 번째 문제의 `exampleSentence`
- `POST /api/v1/test/sessions/{id}/answers` (답안 제출) — `nextQuestion.exampleSentence`
- FILL_IN_BLANK / MULTIPLE_CHOICE는 변경 없음

## 치환 예시
"He had to abandon his car."
→ "He had to _______ his car."

## 테스트 방법
1. SHORT_ANSWER 타입으로 세션 시작
2. 응답의 `question.exampleSentence`에서 정답 단어가 `___` 형태로 마스킹되는지 확인
3. 답안 제출 후 `nextQuestion.exampleSentence`도 동일하게 마스킹되는지 확인
4. 예문 없는 단어 포함 시 `exampleSentence: null` 로 정상 응답되는지 확인