### PR TITLE
✨ feat: 테스트 세션 상세 조회 API 개발 (#53)

### DIFF
--- a/src/main/java/com/sw8080/lookeng/controller/CLAUDE.md
+++ b/src/main/java/com/sw8080/lookeng/controller/CLAUDE.md
@@ -40,6 +40,7 @@
 | POST | `/{sessionId}/answers` | 답안 제출 | O |
 | POST | `/{sessionId}/finish` | 테스트 종료 | O |
 | GET | `/` | 테스트 기록 조회 (페이지네이션) | O |
+| GET | `/{id}` | 테스트 세션 상세 조회 | O |
 
 ## 컨트롤러 공통 패턴
 

--- a/src/main/java/com/sw8080/lookeng/controller/TestSessionController.java
+++ b/src/main/java/com/sw8080/lookeng/controller/TestSessionController.java
@@ -7,6 +7,7 @@ import com.sw8080.lookeng.dto.request.TestSessionRequestDto;
 import com.sw8080.lookeng.dto.response.TestAnswerResponseDto;
 import com.sw8080.lookeng.dto.response.TestFinishResponseDto;
 import com.sw8080.lookeng.dto.response.TestHistoryResponseDto;
+import com.sw8080.lookeng.dto.response.TestSessionDetailResponseDto;
 import com.sw8080.lookeng.dto.response.TestSessionResponseDto;
 import com.sw8080.lookeng.service.TestSessionService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -75,6 +76,24 @@ public class TestSessionController {
         TestFinishResponseDto data = testSessionService.finishSession(userId, sessionId, request);
         return ResponseEntity.ok(new ApiResponse<>(true, "테스트가 종료되었습니다.", data));
     }
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<TestSessionDetailResponseDto>> getSessionDetail(
+            @PathVariable Long id,
+            HttpServletRequest httpRequest) {
+
+        // 1. 로그인 확인 (401)
+        HttpSession session = httpRequest.getSession(false);
+        if (session == null || session.getAttribute("LOGIN_USER_ID") == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponse<>(false, "로그인이 필요합니다.", null));
+        }
+
+        Long userId = (Long) session.getAttribute("LOGIN_USER_ID");
+        TestSessionDetailResponseDto data = testSessionService.getSessionDetail(userId, id);
+
+        return ResponseEntity.ok(new ApiResponse<>(true, "테스트 세션 조회를 성공했습니다.", data));
+    }
+
     @GetMapping
     public ResponseEntity<ApiResponse<TestHistoryResponseDto>> getTestHistory(
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/com/sw8080/lookeng/dto/response/TestSessionDetailResponseDto.java
+++ b/src/main/java/com/sw8080/lookeng/dto/response/TestSessionDetailResponseDto.java
@@ -1,0 +1,74 @@
+package com.sw8080.lookeng.dto.response;
+
+import com.sw8080.lookeng.entity.QuizType;
+import com.sw8080.lookeng.entity.TestAnswer;
+import com.sw8080.lookeng.entity.TestSession;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TestSessionDetailResponseDto {
+
+    private Long sessionId;
+    private QuizType quizType;
+    private int score;
+    private int totalQuestions;
+    private int correctCount;
+    private int incorrectCount;
+    private int elapsedSeconds;
+    private LocalDateTime createdAt;
+    private List<AnswerDto> answers;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AnswerDto {
+        private int sequence;
+        private Long wordId;
+        private String english;
+        private String korean;
+        private String userAnswer;
+        private boolean isCorrect;
+
+        public static AnswerDto from(TestAnswer answer, int sequence) {
+            return AnswerDto.builder()
+                    .sequence(sequence)
+                    .wordId(answer.getWord().getId())
+                    .english(answer.getWord().getEnglish())
+                    .korean(answer.getWord().getKorean())
+                    .userAnswer(answer.getUserInput())
+                    .isCorrect(answer.isCorrect())
+                    .build();
+        }
+    }
+
+    public static TestSessionDetailResponseDto from(TestSession session, List<TestAnswer> answers) {
+        AtomicInteger seq = new AtomicInteger(1);
+        List<AnswerDto> answerDtos = answers.stream()
+                .map(a -> AnswerDto.from(a, seq.getAndIncrement()))
+                .collect(Collectors.toList());
+
+        return TestSessionDetailResponseDto.builder()
+                .sessionId(session.getId())
+                .quizType(session.getQuizType())
+                .score(session.getCorrectCount())
+                .totalQuestions(session.getTotalCount())
+                .correctCount(session.getCorrectCount())
+                .incorrectCount(session.getTotalCount() - session.getCorrectCount())
+                .elapsedSeconds(session.getDurationSec())
+                .createdAt(session.getCreatedAt())
+                .answers(answerDtos)
+                .build();
+    }
+}

--- a/src/main/java/com/sw8080/lookeng/repository/TestAnswerRepository.java
+++ b/src/main/java/com/sw8080/lookeng/repository/TestAnswerRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 public interface TestAnswerRepository extends JpaRepository<TestAnswer, Long> {
     List<TestAnswer> findByTestSessionIdAndIsCorrectFalse(Long sessionId);
 
+    List<TestAnswer> findByTestSessionIdOrderByIdAsc(Long sessionId);
+
     @Query("SELECT COUNT(DISTINCT ta.word.id) FROM TestAnswer ta " +
             "JOIN ta.testSession ts " +
             "WHERE ts.userId = :userId AND ta.isCorrect = true")

--- a/src/main/java/com/sw8080/lookeng/service/TestSessionService.java
+++ b/src/main/java/com/sw8080/lookeng/service/TestSessionService.java
@@ -10,6 +10,7 @@ import com.sw8080.lookeng.dto.request.TestSessionRequestDto;
 import com.sw8080.lookeng.dto.response.TestAnswerResponseDto;
 import com.sw8080.lookeng.dto.response.TestFinishResponseDto;
 import com.sw8080.lookeng.dto.response.TestHistoryResponseDto;
+import com.sw8080.lookeng.dto.response.TestSessionDetailResponseDto;
 import com.sw8080.lookeng.dto.response.TestSessionResponseDto;
 import com.sw8080.lookeng.entity.TestAnswer;
 import com.sw8080.lookeng.entity.TestSession;
@@ -260,6 +261,23 @@ public class TestSessionService {
     private String blankSentence(String english, String exampleSentence) {
         return exampleSentence.replaceAll(
                 "(?i)\\b" + Pattern.quote(english) + "\\b", "_____");
+    }
+
+    @Transactional(readOnly = true)
+    public TestSessionDetailResponseDto getSessionDetail(Long userId, Long sessionId) {
+        // 1. 세션 조회 (404)
+        TestSession session = testSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 세션입니다."));
+
+        // 2. 소유자 확인 (403)
+        if (!session.getUserId().equals(userId)) {
+            throw new ForbiddenException("본인의 테스트 세션에만 접근할 수 있습니다.");
+        }
+
+        // 3. 답안 목록 조회 (제출 순서 기준)
+        List<TestAnswer> answers = testAnswerRepository.findByTestSessionIdOrderByIdAsc(sessionId);
+
+        return TestSessionDetailResponseDto.from(session, answers);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 관련 이슈
Closes #53

## 변경 개요

`GET /api/v1/test/sessions/{id}` 엔드포인트를 추가합니다.
로그인한 사용자가 자신의 특정 테스트 세션을 조회할 때 세션 요약 정보와 전체 답안 목록을 함께 반환합니다.

---

## 변경 사항

### `TestSessionDetailResponseDto` (신규)
- 세션 요약 정보: `sessionId`, `quizType`, `score`, `totalQuestions`, `correctCount`, `incorrectCount`, `elapsedSeconds`, `createdAt`
- 답안 목록: `answers[]` — `sequence`, `wordId`, `english`, `korean`, `userAnswer`, `isCorrect`
- `from(TestSession, List<TestAnswer>)` 정적 팩토리 메서드로 변환 처리
- `sequence`는 DB 저장 순서(`id ASC`) 기준 1부터 부여

### `TestAnswerRepository`
- `findByTestSessionIdOrderByIdAsc(Long sessionId)` 추가 — 제출 순서 보장

### `TestSessionService`
- `getSessionDetail(userId, sessionId)` 추가 (`@Transactional(readOnly = true)`)
  - 세션 미존재 → 404
  - 본인 세션 아님 → 403
  - 답안 목록 조회 후 DTO 변환

### `TestSessionController`
- `GET /{id}` 엔드포인트 추가
  - 미로그인 → 401

---

## 에러 처리

| 상태코드 | 상황 |
|----------|------|
| `401` | 미로그인 |
| `403` | 본인 세션 아님 |
| `404` | 존재하지 않는 세션 id |

---

## 테스트 방법
1. 로그인 후 테스트 세션 시작 (`POST /api/v1/test/sessions`)
2. 답안 제출 (`POST /api/v1/test/sessions/{id}/answers`)
3. `GET /api/v1/test/sessions/{id}` 호출 → `answers[]`에 제출한 답안이 `sequence` 순서대로 포함되는지 확인
4. 타인의 세션 id로 요청 시 `403` 반환되는지 확인
5. 존재하지 않는 id 요청 시 `404` 반환되는지 확인